### PR TITLE
Add typewriter effect for overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   </div>
   <div class="overlay"></div>
   <div class="mobile-overlay" id="mobileOverlay" onclick="enterSite()">
-    <div>tap anywhere</div>
+    <div>tap to open</div>
   </div>
   <div class="content">
     <h1 class="glitch-title">T H I R T Y 3</h1>
@@ -41,7 +41,7 @@
   </div>
   </main>
   <footer>
-    <a href="#">CONTACT</a>
+    <a href="#">&#9993; CONTACT</a>
   </footer>
   <script>
     const text = "sound over style – emotion over ego – music that says what I don't";
@@ -54,9 +54,20 @@
         setTimeout(typeChar, 40);
       }
     }
-    window.addEventListener("load", () => {
-      setTimeout(typeChar, 1500);
-    });
+      window.addEventListener("load", () => {
+        setTimeout(typeChar, 1500);
+      });
+
+      const overlayText = "tap to open";
+      const overlayTarget = document.querySelector("#mobileOverlay div");
+      let overlayIndex = 0;
+      function typeOverlayChar() {
+        if (overlayIndex < overlayText.length) {
+          overlayTarget.textContent += overlayText.charAt(overlayIndex);
+          overlayIndex++;
+          setTimeout(typeOverlayChar, 120);
+        }
+      }
 
     function isMobile() {
       // Include iPad and iPod in mobile detection
@@ -72,11 +83,14 @@
       }, 500);
     }
 
-    window.addEventListener("DOMContentLoaded", () => {
-      if (isMobile()) {
-        document.getElementById("mobileOverlay").style.display = "flex";
-      }
-    });
+      window.addEventListener("DOMContentLoaded", () => {
+        if (isMobile()) {
+          const overlay = document.getElementById("mobileOverlay");
+          overlay.style.display = "flex";
+          overlayTarget.textContent = "";
+          typeOverlayChar();
+        }
+      });
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -54,9 +54,12 @@
         setTimeout(typeChar, 40);
       }
     }
-      window.addEventListener("load", () => {
-        setTimeout(typeChar, 1500);
-      });
+
+    function startTyping() {
+      index = 0;
+      target.textContent = "";
+      setTimeout(typeChar, 500);
+    }
 
       const overlayText = "tap to open";
       const overlayTarget = document.querySelector("#mobileOverlay div");
@@ -80,17 +83,20 @@
       setTimeout(() => {
         overlay.style.display = 'none';
         document.getElementById('bg-video').play();
+        startTyping();
       }, 500);
     }
 
-      window.addEventListener("DOMContentLoaded", () => {
-        if (isMobile()) {
-          const overlay = document.getElementById("mobileOverlay");
-          overlay.style.display = "flex";
-          overlayTarget.textContent = "";
-          typeOverlayChar();
-        }
-      });
+    window.addEventListener('DOMContentLoaded', () => {
+      if (isMobile()) {
+        const overlay = document.getElementById('mobileOverlay');
+        overlay.style.display = 'flex';
+        overlayTarget.textContent = '';
+        typeOverlayChar();
+      } else {
+        startTyping();
+      }
+    });
   </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -73,6 +73,10 @@ footer a {
   text-decoration: none;
   font-weight: bold;
   font-size: 12px;
+  background-color: rgba(255,255,255,0.05);
+  padding: 4px 8px;
+  border: 1px solid white;
+  display: inline-block;
 }
 
 /* Innehållet i mitten */

--- a/style.css
+++ b/style.css
@@ -119,7 +119,7 @@ footer a {
   height: 100%;
   width: 100%;
   z-index: 4;
-  background: rgba(0, 0, 0, 0.8);
+  background: black;
   color: white;
   align-items: center;
   justify-content: center;
@@ -129,8 +129,43 @@ footer a {
   transition: opacity 0.5s;
 }
 
+/* Text container for typewriter effect */
+.mobile-overlay div {
+  overflow: hidden;
+  white-space: nowrap;
+  border-right: 2px solid white;
+  padding-right: 4px;
+  animation: blink-caret 0.8s step-end infinite;
+}
+
+@keyframes blink-caret {
+  50% { border-color: transparent; }
+}
+
 .fade-out {
   opacity: 0;
   transition: opacity 0.5s ease-out;
   pointer-events: none;
+}
+
+/* Anpassningar f\u00f6r mobil */
+@media (max-width: 600px) {
+  nav {
+    flex-direction: row;
+    width: calc(100% - 20px);
+    left: 10px;
+    right: 10px;
+    top: 10px;
+    justify-content: space-between;
+    padding: 0;
+  }
+  nav a {
+    text-align: center;
+    font-size: 12px;
+    padding: 4px 0;
+  }
+  .glitch-title {
+    font-size: 24px;
+    letter-spacing: 4px;
+  }
 }

--- a/style.css
+++ b/style.css
@@ -156,10 +156,11 @@ footer a {
     left: 10px;
     right: 10px;
     top: 10px;
-    justify-content: space-between;
+    justify-content: space-around;
     padding: 0;
   }
   nav a {
+    flex: 1;
     text-align: center;
     font-size: 12px;
     padding: 4px 0;


### PR DESCRIPTION
## Summary
- style the mobile overlay with a solid black background
- animate the overlay text with a typewriter effect that starts on load

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b19726218832fb644c6901c88570a