### PR TITLE
Add nowrap for mobile glitch title

### DIFF
--- a/style.css
+++ b/style.css
@@ -153,6 +153,7 @@ footer a {
   }
   .glitch-title {
     font-size: 24px;
-    letter-spacing: 4px;
+    letter-spacing: 2px;
+    white-space: nowrap;
   }
 }


### PR DESCRIPTION
## Summary
- keep `.glitch-title` text on a single line for small screens
- tighten letter spacing on phones so the heading fits

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684b1fb58744832fb63261186f365e2f