### PR TITLE
Add Memories of Noise album modal and mobile tweaks

### DIFF
--- a/data/memories-of-noise.json
+++ b/data/memories-of-noise.json
@@ -1,0 +1,56 @@
+[
+  {
+    "title": "Eternal EVA",
+    "scUrl": "https://soundcloud.com/thirty_3/eternal-eva",
+    "youtubeUrl": "",
+    "thumb": ""
+  },
+  {
+    "title": "Astral Drift",
+    "scUrl": "https://soundcloud.com/thirty_3/astral-drift",
+    "youtubeUrl": "",
+    "thumb": ""
+  },
+  {
+    "title": "Chain Hole",
+    "scUrl": "https://soundcloud.com/thirty_3/chain-hole",
+    "youtubeUrl": "",
+    "thumb": ""
+  },
+  {
+    "title": "Blendfire",
+    "scUrl": "https://soundcloud.com/thirty_3/blendfire",
+    "youtubeUrl": "",
+    "thumb": ""
+  },
+  {
+    "title": "Mislay (feat. Lidnesty)",
+    "scUrl": "https://soundcloud.com/thirty_3/mislay-feat-lidnesty",
+    "youtubeUrl": "https://youtu.be/tV5tmkoVEO0",
+    "thumb": ""
+  },
+  {
+    "title": "Digital Soul",
+    "scUrl": "https://soundcloud.com/thirty_3/digital-soul",
+    "youtubeUrl": "",
+    "thumb": ""
+  },
+  {
+    "title": "Lide",
+    "scUrl": "https://soundcloud.com/thirty_3/lide",
+    "youtubeUrl": "",
+    "thumb": ""
+  },
+  {
+    "title": "Radiant Desire",
+    "scUrl": "https://soundcloud.com/thirty_3/radiant-desire",
+    "youtubeUrl": "",
+    "thumb": ""
+  },
+  {
+    "title": "Wanderer’s Odyssey",
+    "scUrl": "https://soundcloud.com/thirty_3/wanderers-odyssey",
+    "youtubeUrl": "",
+    "thumb": ""
+  }
+]

--- a/index.html
+++ b/index.html
@@ -52,7 +52,6 @@
   <style>
     /* Gör toppbarens text lite mjukare på mobil */
     @media (max-width: 480px){
-      .topbar nav a{ font-size:12px; padding:6px 10px; }
       .subtitle{ font-size:16px; }
       .intro{ font-size:14px; }
       .mobile-overlay{ font-size:13px; }
@@ -126,8 +125,21 @@
     const ovl = document.getElementById('mobileOverlay');
     const v = document.getElementById('bgVideo');
     function needsTap(){ return /iPhone|iPad|iPod|Android/i.test(navigator.userAgent); }
-    function enableVideo(){
+
+    let overlayDismissed = false;
+    function dismissOverlay(){
+      if (overlayDismissed) return;
+      overlayDismissed = true;
       html.classList.remove('show-mobile-overlay');
+      if (ovl){
+        ovl.classList.add('fade-out');
+        ovl.style.pointerEvents = 'none';
+        setTimeout(()=>{ ovl.style.display = 'none'; }, 480);
+      }
+    }
+
+    function enableVideo(){
+      dismissOverlay();
       if (v && v.paused) { v.play().catch(()=>{}); }
     }
     if (needsTap()){

--- a/style.css
+++ b/style.css
@@ -83,6 +83,13 @@ html, body{
 /* ge plats under topbaren */
 body.home{ padding-top:56px; }
 
+@media (max-width:480px){
+  .topbar{ height:52px; }
+  .topbar nav{ gap:16px; top:10px; }
+  .topbar nav a{ font-size:11px; letter-spacing:.06em; padding:6px 0; }
+  #logo3d-wrap{ left:10px; top:4px; width:100px; height:48px; }
+}
+
 /* ===============================
    Hero / content
 =================================*/

--- a/work-test.html
+++ b/work-test.html
@@ -60,9 +60,24 @@
     .wk-kind{ font-size:11px; color:var(--muted); letter-spacing:.16em; text-transform:uppercase; }
     .wk-name{ font-size:15px; letter-spacing:.02em; color:var(--ink); } /* keep light */
 
-    .wk-actions{ display:flex; gap:8px; padding:0 14px 14px; }
-    .wk-chip{ border:1px solid var(--line); background:var(--chip); color:#fff; font-size:12px; padding:6px 8px; border-radius:6px; text-decoration:none; transition:background .12s ease, border-color .12s ease; }
+    .wk-actions{ display:flex; gap:8px; padding:0 14px 14px; flex-wrap:wrap; }
+    .wk-chip{
+      border:1px solid var(--line);
+      background:var(--chip);
+      color:#fff;
+      font-size:12px;
+      padding:6px 10px;
+      border-radius:6px;
+      text-decoration:none;
+      transition:background .12s ease, border-color .12s ease;
+      display:inline-flex;
+      align-items:center;
+      gap:6px;
+      cursor:pointer;
+    }
     .wk-chip:hover{ background:var(--chipHover); border-color:#fff; }
+    .wk-chip:focus-visible{ outline:2px solid rgba(255,255,255,.35); outline-offset:2px; }
+    button.wk-chip{ font:inherit; }
 
     /* Modal */
     .wk-modal{ position:fixed; inset:0; display:none; align-items:center; justify-content:center; z-index:10000; }
@@ -76,15 +91,36 @@
     }
     @media (max-width:900px){ .wk-dialog{ grid-template-columns:1fr; } }
     .wk-preview{ background:#0b0f11; display:grid; place-items:center; min-height:280px; }
+    @media (max-width:600px){
+      .wk-modal{ align-items:flex-start; }
+      .wk-dialog{ width:100vw; height:100vh; max-height:none; border-radius:0; }
+      .wk-detail{ height:100%; overflow-y:auto; }
+      .wk-preview{ min-height:220px; }
+    }
     .wk-preview img, .wk-preview video, .wk-preview iframe{ width:100%; height:100%; object-fit:cover; border:0; }
     .wk-detail{ padding:18px 18px 20px; display:flex; flex-direction:column; gap:10px; }
     .wk-detail h3{ margin:2px 0 2px; letter-spacing:.02em; color:var(--ink); }
     .wk-detail p{ margin:0; color:#dfe4e6; opacity:.86; line-height:1.5; }
     .wk-detail .wk-row{ display:flex; gap:8px; flex-wrap:wrap; margin-top:8px; }
 
-    .wk-tracks{ display:flex; flex-direction:column; gap:10px; margin-top:4px; }
-    .wk-tracks .item{ border:1px solid var(--line); border-radius:10px; overflow:hidden; background:rgba(255,255,255,.03); }
-    .wk-tracks .item iframe{ width:100%; height:168px; display:block; }
+    .wk-tracks{ display:flex; flex-direction:column; gap:8px; margin-top:10px; }
+    .wk-tracklabel{ font-size:11px; letter-spacing:.16em; text-transform:uppercase; color:var(--muted); margin:0 0 2px; }
+    .wk-tracklist{ display:flex; flex-direction:column; gap:8px; }
+    .track-row{
+      display:flex; align-items:center; gap:12px;
+      border:1px solid var(--line); border-radius:10px;
+      background:rgba(255,255,255,.03);
+      padding:10px; text-align:left;
+      font:inherit; color:inherit; cursor:pointer;
+      transition:border-color .12s ease, background .12s ease, transform .12s ease;
+      appearance:none;
+    }
+    .track-row:hover{ border-color:rgba(255,255,255,.28); background:rgba(255,255,255,.06); }
+    .track-row:focus-visible{ outline:2px solid rgba(255,255,255,.35); outline-offset:2px; }
+    .track-row.active{ border-color:#fff; background:rgba(255,255,255,.08); transform:translateY(-1px); }
+    .track-row img{ width:52px; height:52px; border-radius:8px; object-fit:cover; flex-shrink:0; }
+    .track-row .title{ flex:1; font-size:13px; letter-spacing:.03em; color:var(--ink); }
+    .track-row .badge{ font-size:10px; letter-spacing:.12em; text-transform:uppercase; border:1px solid var(--line); border-radius:999px; padding:2px 6px; background:rgba(255,255,255,.08); color:var(--ink); }
 
     .wk-close{ position:absolute; top:10px; right:10px; border:1px solid var(--line); background:var(--chip); color:#fff; border-radius:8px; padding:6px 9px; cursor:pointer; font-size:13px; }
     .wk-close:hover{ background:var(--chipHover); border-color:#fff; }
@@ -98,7 +134,7 @@
       <a href="https://soundcloud.com/thirty_3" target="_blank">SOUNDCLOUD</a>
       <a href="https://www.youtube.com/@thirty3473" target="_blank">YOUTUBE</a>
       <a href="work-test.html">WORK</a>
-      <a href="index.html#contact">CONTACT</a>
+      <a href="mailto:thirty3contact@gmail.com">CONTACT</a>
     </nav>
   </header>
 
@@ -141,42 +177,49 @@ const PLACEHOLDER = 'image00015.jpeg';
 const scEmbed = (url) =>
   `https://w.soundcloud.com/player/?url=${encodeURIComponent(url)}&visual=true`;
 
+const MEMORIES_SET_URL = 'https://soundcloud.com/thirty_3/sets/memories-of-noise';
+const MEMORIES_DATA_URL = 'data/memories-of-noise.json';
+
 /* ---------- PROJECTS (manuellt) ---------- */
 let PROJECTS = [
-  /* ====== ALBUM: Memories of Noise ====== */
   {
-    title: "Memories of Noise (album)",
+    title: "Memories of Noise",
     kind: "solo",
     type: "album",
     thumb: "auto",
-    media: { type: "embed", src: scEmbed("https://soundcloud.com/thirty_3/sets/memories-of-noise") },
-    desc: "Nine tracks. Electronic/ambient/noise. Produced & mixed by THIRTY3.",
+    media: { type: "embed", src: scEmbed(MEMORIES_SET_URL) },
+    preview: null,
+    desc: "Nine-track album exploring electronic, ambient and noise textures. Produced & mixed by THIRTY3.",
     links: [
-      { label: "View set", href: "https://soundcloud.com/thirty_3/sets/memories-of-noise" }
+      { label: "Listen (SoundCloud set)", href: MEMORIES_SET_URL }
     ],
-    children: [
-      { title: "Eternal EVA",  media:{type:"embed", src: scEmbed("https://soundcloud.com/thirty_3/eternal-eva")} },
-      { title: "Astral Drift", media:{type:"embed", src: scEmbed("https://soundcloud.com/thirty_3/astral-drift")} },
-      { title: "Chain Hole",   media:{type:"embed", src: scEmbed("https://soundcloud.com/thirty_3/chain-hole")}, links:[{label:"View on Bandcamp", href:"https://thirty3.bandcamp.com/track/chain-hole"}] },
-      { title: "Blendfire",    media:{type:"embed", src: scEmbed("https://soundcloud.com/thirty_3/blendfire")} },
-      { title: "Mislay (feat. Lidnesty)", media:{type:"embed", src: scEmbed("https://soundcloud.com/thirty_3/mislay-feat-lidnesty")}, links:[{label:"Watch MV", href:"https://youtu.be/tV5tmkoVEO0"}]},
-      { title: "Digital Soul", media:{type:"embed", src: scEmbed("https://soundcloud.com/thirty_3/digital-soul")} },
-      { title: "Lide",         media:{type:"embed", src: scEmbed("https://soundcloud.com/thirty_3/lide")} },
-      { title: "Radiant Desire", media:{type:"embed", src: scEmbed("https://soundcloud.com/thirty_3/radiant-desire")} },
-      { title: "Wanderer’s Odyssey", media:{type:"embed", src: scEmbed("https://soundcloud.com/thirty_3/wanderers-odyssey")}, links:[{label:"View set", href:"https://soundcloud.com/thirty_3/sets/memories-of-noise"}] },
-    ]
+    dataUrl: MEMORIES_DATA_URL,
+    setUrl: MEMORIES_SET_URL,
+    children: []
   },
 
   /* ====== SOLO (singlar/EP) ====== */
   {
     title: "The Call Below",
     kind: "solo",
-    thumb: "auto",
+    thumb: "https://img.youtube.com/vi/Y_YEgEOXtAM/hqdefault.jpg",
     media: { type: "embed", src: scEmbed("https://soundcloud.com/thirty_3/the-call-below") },
     desc: "Single released on Bandcamp.",
     links: [
-      { label: "Watch MV", href: "https://youtu.be/Y_YEgEOXtAM" },
+      { label: "Listen (SoundCloud)", href: "https://soundcloud.com/thirty_3/the-call-below" },
+      { label: "Watch (YouTube)", action: "preview", media: { type: "embed", src: youtubeEmbed("https://youtu.be/Y_YEgEOXtAM") }, showOnCard: false },
       { label: "View on Bandcamp", href: "https://thirty3.bandcamp.com/track/the-call-below" }
+    ]
+  },
+  {
+    title: "Mislay (feat. Lidnesty)",
+    kind: "solo",
+    thumb: "https://img.youtube.com/vi/tV5tmkoVEO0/hqdefault.jpg",
+    media: { type: "embed", src: scEmbed("https://soundcloud.com/thirty_3/mislay-feat-lidnesty") },
+    desc: "Single featuring Lidnesty, also part of Memories of Noise.",
+    links: [
+      { label: "Listen (SoundCloud)", href: "https://soundcloud.com/thirty_3/mislay-feat-lidnesty" },
+      { label: "Watch (YouTube)", action: "preview", media: { type: "embed", src: youtubeEmbed("https://youtu.be/tV5tmkoVEO0") }, showOnCard: false }
     ]
   },
   {
@@ -321,10 +364,32 @@ function youtubeIdFrom(url){
   return m ? m[1] : null;
 }
 
+function youtubeEmbed(url){
+  const id = youtubeIdFrom(url || '');
+  return id ? `https://www.youtube.com/embed/${id}` : (url || '');
+}
+
+const scThumbCache = new Map();
+
+async function fetchSoundCloudThumb(scUrl){
+  if (!scUrl) return '';
+  if (scThumbCache.has(scUrl)) return scThumbCache.get(scUrl);
+  try {
+    const o = await fetch(`https://soundcloud.com/oembed?format=json&url=${encodeURIComponent(scUrl)}`).then(r=>r.json());
+    const thumb = o && o.thumbnail_url ? o.thumbnail_url.replace('-t500x500','-t300x300') : '';
+    scThumbCache.set(scUrl, thumb);
+    return thumb;
+  } catch (e) {
+    scThumbCache.set(scUrl, '');
+    return '';
+  }
+}
+
 async function resolveThumb(p){
   if (p.thumb && p.thumb !== 'auto') return p.thumb;
-  if (!p.media) return PLACEHOLDER;
-  const url = p.media.src || '';
+  if (p.preview?.type === 'image' && p.preview?.src) return p.preview.src;
+  if (p.media?.type === 'image' && p.media?.src) return p.media.src;
+  const url = p.media?.src || '';
 
   if (/youtube\.com|youtu\.be/.test(url)) {
     const id = youtubeIdFrom(url);
@@ -340,10 +405,13 @@ async function resolveThumb(p){
   if (/soundcloud\.com/.test(url) || /w\.soundcloud\.com\/player/.test(url)) {
     try {
       let sc = url;
-      const q = new URL(url).searchParams.get('url');
-      if (q) sc = decodeURIComponent(q);
-      const o = await fetch(`https://soundcloud.com/oembed?format=json&url=${encodeURIComponent(sc)}`).then(r=>r.json());
-      if (o && o.thumbnail_url) return o.thumbnail_url.replace('-t500x500','-t300x300');
+      try {
+        const parsed = new URL(url);
+        const q = parsed.searchParams.get('url');
+        if (q) sc = decodeURIComponent(q);
+      } catch {}
+      const thumb = await fetchSoundCloudThumb(sc);
+      if (thumb) return thumb;
     } catch(e){}
   }
   return PLACEHOLDER;
@@ -373,16 +441,18 @@ function createCard(p){
   left.append(kind, name);
   meta.append(left);
 
-  const actions = document.createElement('div'); 
+  const actions = document.createElement('div');
   actions.className = 'wk-actions';
   (p.links||[]).forEach(l=>{
+    if (!l.href || l.showOnCard === false) return;
     const a = document.createElement('a');
     a.href = l.href; a.target = '_blank'; a.rel='noopener';
     a.className = 'wk-chip'; a.textContent = l.label;
     actions.appendChild(a);
   });
 
-  card.append(img, meta, actions);
+  card.append(img, meta);
+  if (actions.childElementCount) card.append(actions);
   card.addEventListener('click', ()=> openModal(p));
   card.addEventListener('keydown', (e)=>{ if(e.key==='Enter') openModal(p); });
 
@@ -391,8 +461,9 @@ function createCard(p){
 
 function passesFilter(p){
   if (current === 'all') return true;
-  if (current === 'solo') return (p.kind === 'solo' || p.kind === 'remix'); // remixes ingår i Solo
-  return p.kind === current;
+  const kind = (p.kind || 'solo');
+  if (current === 'solo') return kind === 'solo';
+  return kind === current;
 }
 
 function render(){
@@ -417,50 +488,157 @@ const descEl  = document.getElementById('wkDesc');
 const linksEl = document.getElementById('wkLinks');
 const tracksEl= document.getElementById('wkTracks');
 
+function renderPreviewContent(media, options = {}){
+  const fallback = options.fallback || PLACEHOLDER;
+  const label = options.title || titleEl.textContent || 'Preview';
+
+  preview.innerHTML = '';
+
+  if (!media) {
+    const img = document.createElement('img');
+    img.src = fallback;
+    img.alt = label;
+    preview.appendChild(img);
+    return;
+  }
+
+  if (media.type === 'video') {
+    const v = document.createElement('video');
+    v.src = media.src;
+    v.controls = true;
+    v.playsInline = true;
+    v.autoplay = Boolean(media.autoplay);
+    v.title = label;
+    preview.appendChild(v);
+    return;
+  }
+
+  if (media.type === 'embed') {
+    const iframe = document.createElement('iframe');
+    iframe.src = media.src;
+    iframe.allow = media.allow || 'autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share';
+    iframe.referrerPolicy = media.referrerPolicy || 'strict-origin-when-cross-origin';
+    iframe.loading = 'lazy';
+    iframe.title = label;
+    preview.appendChild(iframe);
+    return;
+  }
+
+  const img = document.createElement('img');
+  img.src = media.src || fallback;
+  img.alt = label;
+  preview.appendChild(img);
+}
+
 function openModal(p){
   titleEl.textContent = p.title;
-  descEl.textContent  = p.desc || '';
-  linksEl.innerHTML   = '';
-  (p.links||[]).forEach(l=>{
-    const a = document.createElement('a');
-    a.href = l.href; a.target = '_blank'; a.rel='noopener';
-    a.className = 'wk-chip'; a.textContent = l.label;
-    linksEl.appendChild(a);
-  });
-
-  // main preview
-  preview.innerHTML = '';
-  if(p.media?.type === 'video'){
-    const v = document.createElement('video');
-    v.src = p.media.src; v.controls = true; v.playsInline = true;
-    preview.appendChild(v);
-  } else if (p.media?.type === 'embed'){
-    const iframe = document.createElement('iframe');
-    iframe.src = p.media.src;
-    iframe.allow = "autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share";
-    iframe.referrerPolicy = "strict-origin-when-cross-origin";
-    preview.appendChild(iframe);
+  const desc = (p.desc || '').trim();
+  if (desc) {
+    descEl.textContent = desc;
+    descEl.hidden = false;
   } else {
-    const im = document.createElement('img');
-    im.src = p.media?.src || PLACEHOLDER; im.alt = p.title;
-    preview.appendChild(im);
+    descEl.textContent = '';
+    descEl.hidden = true;
   }
+  linksEl.innerHTML   = '';
+
+  const trackButtons = new Map();
+  let activeTrackButton = null;
+
+  function highlightTrack(title){
+    const key = (title || '').trim().toLowerCase();
+    const entry = trackButtons.get(key);
+    if (!entry) return;
+    if (activeTrackButton && activeTrackButton !== entry.button) {
+      activeTrackButton.classList.remove('active');
+    }
+    activeTrackButton = entry.button;
+    activeTrackButton.classList.add('active');
+  }
+
+  function setPreview(media, title, options = {}){
+    let fallbackSrc = options.fallback;
+    if (!fallbackSrc && p.preview?.type === 'image' && p.preview?.src) fallbackSrc = p.preview.src;
+    if (!fallbackSrc && p.thumb && p.thumb !== 'auto') fallbackSrc = p.thumb;
+    renderPreviewContent(media, { title, fallback: fallbackSrc || PLACEHOLDER });
+  }
+
+  function createLinkControl(link){
+    if (!link) return null;
+    if (link.href){
+      const a = document.createElement('a');
+      a.href = link.href;
+      a.target = '_blank';
+      a.rel = 'noopener';
+      a.className = 'wk-chip';
+      a.textContent = link.label;
+      return a;
+    }
+    if (link.action === 'preview' && link.media){
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'wk-chip';
+      btn.textContent = link.label;
+      btn.addEventListener('click', ()=>{
+        if (link.trackTitle) highlightTrack(link.trackTitle);
+        setPreview(link.media, link.trackTitle || link.label, { fallback: link.thumb || p.thumb });
+      });
+      return btn;
+    }
+    return null;
+  }
+
+  (p.links||[]).forEach(link => {
+    const el = createLinkControl(link);
+    if (el) linksEl.appendChild(el);
+  });
+  linksEl.hidden = !linksEl.childElementCount;
+
+  const defaultPreview = p.preview || p.media || ((p.thumb && p.thumb !== 'auto') ? { type: 'image', src: p.thumb } : null);
+  setPreview(defaultPreview, p.title);
 
   // album tracks (if any)
   tracksEl.innerHTML = '';
+  tracksEl.scrollTop = 0;
   if (Array.isArray(p.children) && p.children.length){
     tracksEl.hidden = false;
+    const label = document.createElement('p');
+    label.className = 'wk-tracklabel';
+    label.textContent = 'Tracklist';
+    const list = document.createElement('div');
+    list.className = 'wk-tracklist';
+    tracksEl.append(label, list);
+
     p.children.forEach((t)=>{
-      const wrap = document.createElement('div');
-      wrap.className = 'item';
-      if (t.media?.type === 'embed'){
-        const f = document.createElement('iframe');
-        f.src = t.media.src;
-        f.allow = "autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share";
-        f.referrerPolicy = "strict-origin-when-cross-origin";
-        wrap.appendChild(f);
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'track-row';
+      const img = document.createElement('img');
+      img.src = t.thumb || PLACEHOLDER;
+      img.alt = `${t.title || 'Track'} artwork`;
+      const name = document.createElement('span');
+      name.className = 'title';
+      name.textContent = t.title || 'Untitled';
+      btn.append(img, name);
+      if (t.youtubeUrl){
+        const badge = document.createElement('span');
+        badge.className = 'badge';
+        badge.textContent = 'MV';
+        btn.appendChild(badge);
       }
-      tracksEl.appendChild(wrap);
+      list.appendChild(btn);
+
+      const key = (t.title || '').trim().toLowerCase();
+      trackButtons.set(key, { button: btn, track: t });
+
+      btn.addEventListener('click', ()=>{
+        highlightTrack(t.title);
+        if (t.media){
+          setPreview(t.media, t.title, { fallback: t.thumb });
+        } else {
+          setPreview(null, t.title, { fallback: t.thumb });
+        }
+      });
     });
   } else {
     tracksEl.hidden = true;
@@ -492,8 +670,65 @@ async function loadAutoProjects() {
   } catch {}
 }
 
+async function loadMemoriesAlbum(){
+  const album = PROJECTS.find(p => p.dataUrl === MEMORIES_DATA_URL);
+  if (!album) return;
+
+  try {
+    const res = await fetch(`${album.dataUrl}?v=${Date.now()}`, { cache: 'no-store' });
+    if (!res.ok) throw new Error('memories-of-noise.json missing');
+    const list = await res.json();
+
+    const tracks = await Promise.all((list || []).map(async (track) => {
+      const scUrl = track.scUrl || '';
+      const youtubeUrl = track.youtubeUrl || '';
+      let thumb = track.thumb || '';
+      if (!thumb) thumb = await fetchSoundCloudThumb(scUrl);
+      return {
+        title: track.title || 'Untitled',
+        thumb: thumb || PLACEHOLDER,
+        scUrl,
+        youtubeUrl,
+        media: scUrl ? { type: 'embed', src: scEmbed(scUrl) } : null,
+        altMedia: youtubeUrl ? { type: 'embed', src: youtubeEmbed(youtubeUrl) } : null,
+      };
+    }));
+
+    album.children = tracks;
+
+    const cover = (await fetchSoundCloudThumb(album.setUrl || MEMORIES_SET_URL)) || tracks[0]?.thumb;
+    if (cover) {
+      album.thumb = cover;
+      album.preview = { type: 'image', src: cover };
+    }
+
+    if (!album.media && album.setUrl) {
+      album.media = { type: 'embed', src: scEmbed(album.setUrl) };
+    }
+
+    const mvTrack = tracks.find(t => t.youtubeUrl);
+    if (mvTrack) {
+      const hasMvButton = (album.links || []).some(l => (l.label || '').toLowerCase().includes('watch'));
+      if (!hasMvButton) {
+        album.links = [...(album.links || []), {
+          label: 'Watch MV',
+          action: 'preview',
+          media: { type: 'embed', src: youtubeEmbed(mvTrack.youtubeUrl) },
+          trackTitle: mvTrack.title,
+          showOnCard: false,
+        }];
+      }
+    }
+  } catch (err) {
+    console.warn('Memories of Noise data failed to load', err);
+  }
+}
+
 (async function boot(){
-  await loadAutoProjects();
+  await Promise.all([
+    loadAutoProjects(),
+    loadMemoriesAlbum()
+  ]);
   render();
 })();
   </script>


### PR DESCRIPTION
## Summary
- build a Memories of Noise album card that loads track data from JSON and adds in-modal track previews with SoundCloud and video embeds
- update single and remix metadata to surface YouTube thumbnails, modal preview actions, and a dedicated Remixes filter
- tune mobile layout for the navigation bar and dismiss the tap-to-open overlay after the first interaction

## Testing
- not run (frontend changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cfc0e285d0832f977ed05b7aaddd15