### PR TITLE
Ensure 3D logo overlay renders reliably

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,9 @@
     /* Säkerställ att kontaktlänken alltid är klickbar överst */
     .topbar nav a[href^="mailto:"]{ border-color: var(--chipBorder); }
     .topbar nav a[href^="mailto:"]:hover{ background: var(--chipHover); }
+    #logo3d-wrap{ position:fixed; left:12px; top:8px; width:84px; height:84px; z-index:10001; pointer-events:none; }
+    #logo3d{ width:100%; height:100%; display:block; }
+    @media (max-width:600px){ #logo3d-wrap{ left:8px; top:8px; width:64px; height:64px; } }
     /* ”Tap to open”-lagret */
     .mobile-overlay{
       position:absolute; inset:0;
@@ -76,7 +79,6 @@
 <body class="home">
   <!-- Top bar -->
   <header class="topbar">
-    <div id="logo3d-wrap"><canvas id="logo3d"></canvas></div>
     <nav aria-label="Primary">
       <a href="https://www.instagram.com/_thirty3_/" target="_blank" rel="noopener">INSTAGRAM</a>
       <a href="https://soundcloud.com/thirty_3" target="_blank" rel="noopener">SOUNDCLOUD</a>
@@ -86,6 +88,7 @@
       <a href="mailto:thirty3contact@gmail.com" aria-label="Email THIRTY3">CONTACT</a>
     </nav>
   </header>
+  <div id="logo3d-wrap"><canvas id="logo3d"></canvas></div>
 
   <!-- Background video + overlay -->
   <main>
@@ -146,80 +149,72 @@
   <script src="https://unpkg.com/three@0.159.0/build/three.min.js"></script>
   <script src="https://unpkg.com/three@0.159.0/examples/js/loaders/OBJLoader.js"></script>
   <script>
-  (function(){
+  (function () {
     const cvs = document.getElementById('logo3d');
-    if(!cvs) return;
+    if (!cvs || !window.THREE) { console.warn('Three.js init skipped'); return; }
 
-    // Renderer
     const renderer = new THREE.WebGLRenderer({ canvas: cvs, alpha: true, antialias: true });
+    if (!renderer.getContext()) { console.warn('Three.js renderer unavailable (no WebGL context)'); return; }
     renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
 
-    // Scene & camera
     const scene = new THREE.Scene();
     const cam = new THREE.PerspectiveCamera(35, 1, 0.1, 100);
-    cam.position.set(0, 0, 3.2);
+    cam.position.set(0.8, 0.6, 2.2);
+    scene.add(cam);
 
-    // Resize
+    scene.add(new THREE.AmbientLight(0xffffff, 0.9));
+    const dir = new THREE.DirectionalLight(0xffffff, 1.0);
+    dir.position.set(2,2,3);
+    scene.add(dir);
+
+    const fallback = new THREE.Mesh(
+      new THREE.BoxGeometry(1,1,1),
+      new THREE.MeshStandardMaterial({ color:0xe7eceb, metalness:0.2, roughness:0.7 })
+    );
+    fallback.scale.setScalar(0.6);
+    scene.add(fallback);
+
     function resize(){
-      const w = cvs.clientWidth || 96;
-      const h = cvs.clientHeight || 64;
+      const w = cvs.clientWidth || 84;
+      const h = cvs.clientHeight || 84;
       renderer.setSize(w, h, false);
-      cam.aspect = w / h;
-      cam.updateProjectionMatrix();
+      cam.aspect = w/h; cam.updateProjectionMatrix();
     }
     resize(); window.addEventListener('resize', resize);
 
-    // Lights
-    scene.add(new THREE.AmbientLight(0xffffff, .85));
-    const dir = new THREE.DirectionalLight(0xffffff, .9);
-    dir.position.set(2,3,4);
-    scene.add(dir);
+    function fitAndCenter(obj, target = 1.2){
+      const box = new THREE.Box3().setFromObject(obj);
+      const size = box.getSize(new THREE.Vector3());
+      const maxDim = Math.max(size.x, size.y, size.z) || 1;
+      const center = box.getCenter(new THREE.Vector3());
+      obj.position.sub(center);
+      obj.scale.setScalar(target / maxDim);
+      obj.rotation.set(0.2, 0.6, 0.0);
+    }
 
-    // Fallback (liten wireframe-kub)
-    const fallback = new THREE.Mesh(
-      new THREE.BoxGeometry(1,1,1),
-      new THREE.MeshStandardMaterial({ color:0x8ecceb, metalness:.2, roughness:.8, wireframe:true })
-    );
-    scene.add(fallback);
-
-    // Renderloop
+    const OBJ_URL = new URL('Thirty3_Live_Logo.obj', window.location.href).toString();
+    const loader = new THREE.OBJLoader();
     let liveObj = null;
+
+    loader.load(OBJ_URL, (obj) => {
+      obj.traverse((m) => {
+        if (m.isMesh && !m.material) {
+          m.material = new THREE.MeshStandardMaterial({ color:0xe7eceb, metalness:0.25, roughness:0.6 });
+        }
+      });
+      fitAndCenter(obj);
+      scene.remove(fallback);
+      scene.add(obj);
+      liveObj = obj;
+    }, undefined, (err) => {
+      console.error('OBJ load error:', err); // fallback cube stays visible
+    });
+
     (function tick(){
-      (liveObj || fallback).rotation.y += 0.02;
+      (liveObj || fallback).rotation.y += 0.01;
       renderer.render(scene, cam);
       requestAnimationFrame(tick);
     })();
-
-    // Hjälpare: autoskala + centrera objekt
-    function fitAndCenter(obj){
-      const box = new THREE.Box3().setFromObject(obj);
-      const sizeV = box.getSize(new THREE.Vector3());
-      const maxDim = Math.max(sizeV.x, sizeV.y, sizeV.z) || 1;
-      const center = box.getCenter(new THREE.Vector3());
-      obj.position.sub(center);
-      obj.scale.setScalar(1.6 / maxDim);
-      obj.rotation.set(0.2, 0.6, 0);
-    }
-
-    // Ladda OBJ (fil i repo-roten)
-    const OBJ_URL = new URL('Thirty3_Live_Logo.obj', window.location.href).toString();
-    const loader = new THREE.OBJLoader();
-    loader.load(
-      OBJ_URL,
-      (obj) =>{
-        obj.traverse(m=>{
-          if(m.isMesh){
-            m.material = new THREE.MeshStandardMaterial({ color:0x8ecceb, metalness:.2, roughness:.8 });
-          }
-        });
-        fitAndCenter(obj);
-        scene.remove(fallback);
-        liveObj = obj;
-        scene.add(obj);
-      },
-      undefined,
-      (err)=>{ console.error('OBJ load error', err); }
-    );
   })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add a fixed-position 3D logo wrapper so the canvas stays above the top bar without blocking clicks
- replace the Three.js logo bootstrap with a resilient loader that keeps a rotating fallback cube when the OBJ is unavailable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfc1e05db4832f81dadffc63c2eae8