### PR TITLE
Add hidden About section scaffold

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,6 +112,19 @@
 
     <!-- Contact anchor (visuell sektion kvar om du länkar internt senare) -->
     <section id="contact" style="display:none;"></section>
+
+    <!-- About overlay (hidden unless body has .about) -->
+    <section id="about" aria-labelledby="about-title">
+      <div class="about-inner">
+        <div class="about-portrait" aria-hidden="true">
+          <span>portrait placeholder</span>
+        </div>
+        <div class="about-copy">
+          <h2 id="about-title">About THIRTY3</h2>
+          <p class="about-bio">Bio coming soon. This placeholder will be replaced with the official story.</p>
+        </div>
+      </div>
+    </section>
   </main>
 
   <!-- Scripts: typing + mobil + glitch -->

--- a/style.css
+++ b/style.css
@@ -115,6 +115,62 @@ body.home{ padding-top:56px; }
 }
 
 /* ===============================
+   About overlay (feature-flagged)
+=================================*/
+#about{
+  display:none;
+  position:fixed; inset:0;
+  padding:120px 8vw 80px;
+  background:rgba(0,0,0,.86);
+  backdrop-filter:blur(6px);
+  z-index:3;
+  overflow-y:auto;
+}
+
+body.about #about{ display:block; }
+body.about .content{ display:none; }
+
+.about-inner{
+  max-width:960px;
+  margin:0 auto;
+  display:grid;
+  grid-template-columns:minmax(180px,260px) minmax(0,1fr);
+  gap:48px;
+  align-items:center;
+}
+
+.about-portrait{
+  width:100%;
+  aspect-ratio:3/4;
+  border:1px dashed var(--chipBorder);
+  background:rgba(255,255,255,.06);
+  display:flex; align-items:center; justify-content:center;
+  text-transform:uppercase;
+  letter-spacing:.32em;
+  font-size:12px;
+  color:rgba(231,236,235,.7);
+}
+.about-portrait span{
+  display:block;
+  text-align:center;
+  letter-spacing:.24em;
+}
+
+.about-copy h2{
+  margin:0 0 16px;
+  font-size:clamp(26px, 4vw, 40px);
+  letter-spacing:.1em;
+  text-transform:uppercase;
+}
+
+.about-bio{
+  margin:0;
+  max-width:60ch;
+  line-height:1.6;
+  opacity:.85;
+}
+
+/* ===============================
    Footer (kontakt “send a signal”)
 =================================*/
 footer{
@@ -211,6 +267,14 @@ body.work{ overflow-y:auto; background:#000; }
   .split{ grid-template-columns:1fr; }
   .split-media{ min-height:56vh; }
   .split-copy{ padding:14vw 8vw; }
+  body.about #about{ padding:100px 6vw 70px; }
+  .about-inner{
+    grid-template-columns:1fr;
+    text-align:center;
+    gap:36px;
+  }
+  .about-portrait{ max-width:260px; margin:0 auto; }
+  .about-bio{ margin:0 auto; }
 }
 @media (max-width:700px){
   .topbar{ height:50px; }
@@ -218,4 +282,5 @@ body.work{ overflow-y:auto; background:#000; }
   .topbar nav a{ font-size:12px; }
   #logo3d-wrap{ display:none; } /* dölj 3D-logga på små skärmar */
   body.home{ padding-top:50px; }
+  body.about #about{ padding:90px 6vw 56px; }
 }


### PR DESCRIPTION
## Summary
- add an "About" section scaffold to the home page with placeholder portrait and bio content
- hide the section by default and toggle its visibility with a `.about` body class
- style the overlay layout and ensure it adapts to smaller screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfc8f8e9d8832fb4e2595b5a16f002