### PR TITLE
Use SoundCloud embed for Mitsubishi Facelift card

### DIFF
--- a/work-test.html
+++ b/work-test.html
@@ -320,11 +320,12 @@ let PROJECTS = [
   {
     title: "Mitsubishi Facelift — N I T E F I S H",
     kind: "collab",
-    thumb: PLACEHOLDER,
-    media: { type: "image", src: PLACEHOLDER },
+    thumb: "auto",
+    media: { type: "embed", src: scEmbed("https://soundcloud.com/nitefishofficial/mitsubishi-facelift") },
     desc: "Produced · Mixed · Mastered by THIRTY3.",
     links: [
-      { label: "Read (Kmag article)", href: "https://kmag.se/2024/06/09/n-i-t-e-f-i-s-h-slapper-singeln-mitsubishi-facelift-fran-kommande-ep/" }
+      { label: "Read (Kmag article)", href: "https://kmag.se/2024/06/09/n-i-t-e-f-i-s-h-slapper-singeln-mitsubishi-facelift-fran-kommande-ep/" },
+      { label: "Listen (SoundCloud)", href: "https://soundcloud.com/nitefishofficial/mitsubishi-facelift" }
     ]
   },
   {


### PR DESCRIPTION
## Summary
- switch the Mitsubishi Facelift project to use the SoundCloud embed
- allow the card to pull the SoundCloud artwork automatically and keep existing copy
- add a direct SoundCloud listening link alongside the existing article reference

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cfc8ef21f4832fafa192bb62fd16b2