### PR TITLE
Fix Memories of Noise modal SoundCloud embeds

### DIFF
--- a/work-test.html
+++ b/work-test.html
@@ -174,10 +174,67 @@
    ========================================================= */
 const PLACEHOLDER = 'image00015.jpeg';
 
-const scEmbed = (url) =>
-  `https://w.soundcloud.com/player/?url=${encodeURIComponent(url)}&visual=true`;
+const SOUND_CLOUD_KEEP_PARAMS = ['secret_token', 'in'];
+
+function normalizeSoundCloudUrl(url, options = {}){
+  if (!url) return '';
+  let input = `${url}`.trim();
+  if (!input) return '';
+  if (!/^https?:\/\//i.test(input)) {
+    input = `https://${input.replace(/^\/+/, '')}`;
+  }
+  input = input.replace(/^http:\/\//i, 'https://');
+
+  try {
+    const parsed = new URL(input);
+    if (/^(?:www\.|m\.)?soundcloud\.com$/i.test(parsed.hostname)) {
+      parsed.hostname = 'soundcloud.com';
+    }
+
+    const keepParams = new Set(options.keepParams || SOUND_CLOUD_KEEP_PARAMS);
+    const originalParams = new URLSearchParams(parsed.search);
+    const filtered = new URLSearchParams();
+    keepParams.forEach(key => {
+      if (originalParams.has(key)) filtered.set(key, originalParams.get(key));
+    });
+
+    if (options.contextUrl && !filtered.has('in')) {
+      const contextParam = getSoundCloudContextParam(options.contextUrl);
+      if (contextParam) filtered.set('in', contextParam);
+    }
+
+    parsed.search = filtered.toString() ? `?${filtered.toString()}` : '';
+    parsed.hash = '';
+    return parsed.toString();
+  } catch (_) {
+    return input;
+  }
+}
+
+function getSoundCloudContextParam(url){
+  try {
+    const parsed = new URL(url);
+    if (!/soundcloud\.com$/i.test(parsed.hostname)) return '';
+    const path = parsed.pathname.replace(/\/+$/,'').replace(/^\/+/, '');
+    return path || '';
+  } catch (_) {
+    return '';
+  }
+}
+
+const scEmbed = (url, options = {}) => {
+  const normalized = normalizeSoundCloudUrl(url, options);
+  if (!normalized) return '';
+  const params = new URLSearchParams();
+  params.set('url', normalized);
+  params.set('visual', options.visual === false ? 'false' : 'true');
+  if (options.color) params.set('color', options.color.replace('#',''));
+  if (options.autoPlay !== undefined) params.set('auto_play', options.autoPlay ? 'true' : 'false');
+  return `https://w.soundcloud.com/player/?${params.toString()}`;
+};
 
 const MEMORIES_SET_URL = 'https://soundcloud.com/thirty_3/sets/memories-of-noise';
+const MEMORIES_SET_CANONICAL = normalizeSoundCloudUrl(MEMORIES_SET_URL);
 const MEMORIES_DATA_URL = 'data/memories-of-noise.json';
 
 /* ---------- PROJECTS (manuellt) ---------- */
@@ -187,14 +244,14 @@ let PROJECTS = [
     kind: "solo",
     type: "album",
     thumb: "auto",
-    media: { type: "embed", src: scEmbed(MEMORIES_SET_URL) },
+    media: { type: "embed", src: scEmbed(MEMORIES_SET_CANONICAL) },
     preview: null,
     desc: "Nine-track album exploring electronic, ambient and noise textures. Produced & mixed by THIRTY3.",
     links: [
-      { label: "Listen (SoundCloud set)", href: MEMORIES_SET_URL }
+      { label: "View set", href: MEMORIES_SET_CANONICAL }
     ],
     dataUrl: MEMORIES_DATA_URL,
-    setUrl: MEMORIES_SET_URL,
+    setUrl: MEMORIES_SET_CANONICAL,
     children: []
   },
 
@@ -540,20 +597,63 @@ function openModal(p){
     descEl.textContent = '';
     descEl.hidden = true;
   }
-  linksEl.innerHTML   = '';
+
+  const baseLinks = Array.isArray(p.links) ? p.links.map(link => ({ ...link })) : [];
+  linksEl.innerHTML = '';
 
   const trackButtons = new Map();
   let activeTrackButton = null;
 
+  const keyFor = (title) => (title || '').trim().toLowerCase();
+
+  function mergeLinks(list = []){
+    const seen = new Set();
+    const out = [];
+    list.forEach(link => {
+      if (!link) return;
+      const labelKey = (link.label || '').trim().toLowerCase();
+      const hrefKey = link.href ? `href:${link.href}` : '';
+      const actionKey = link.action ? `action:${link.action}` : '';
+      const key = `${labelKey}|${hrefKey}|${actionKey}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      out.push({ ...link });
+    });
+    return out;
+  }
+
+  function renderLinks(list = baseLinks){
+    linksEl.innerHTML = '';
+    mergeLinks(list).forEach(link => {
+      const el = createLinkControl(link);
+      if (el) linksEl.appendChild(el);
+    });
+    linksEl.hidden = !linksEl.childElementCount;
+  }
+
   function highlightTrack(title){
-    const key = (title || '').trim().toLowerCase();
-    const entry = trackButtons.get(key);
-    if (!entry) return;
+    const entry = trackButtons.get(keyFor(title));
+    if (!entry) return null;
     if (activeTrackButton && activeTrackButton !== entry.button) {
       activeTrackButton.classList.remove('active');
     }
     activeTrackButton = entry.button;
     activeTrackButton.classList.add('active');
+    return entry.track;
+  }
+
+  function applyTrackLinks(track){
+    if (!track) {
+      renderLinks(baseLinks);
+      return;
+    }
+    const extras = [];
+    const listenUrl = track.listenUrl || track.scUrl;
+    if (listenUrl) extras.push({ label: 'Listen (SoundCloud)', href: listenUrl });
+    if (Array.isArray(track.links) && track.links.length) {
+      extras.push(...track.links);
+    }
+    renderLinks([...extras, ...baseLinks]);
   }
 
   function setPreview(media, title, options = {}){
@@ -561,6 +661,20 @@ function openModal(p){
     if (!fallbackSrc && p.preview?.type === 'image' && p.preview?.src) fallbackSrc = p.preview.src;
     if (!fallbackSrc && p.thumb && p.thumb !== 'auto') fallbackSrc = p.thumb;
     renderPreviewContent(media, { title, fallback: fallbackSrc || PLACEHOLDER });
+  }
+
+  function showTrack(title, opts = {}){
+    const track = highlightTrack(title);
+    const media = (opts.media !== undefined) ? opts.media : (track?.media || track?.altMedia || null);
+    const label = opts.label || track?.title || title || p.title;
+    const fallback = opts.fallback || track?.thumb;
+    setPreview(media, label, { fallback });
+    if (track) {
+      applyTrackLinks(track);
+    } else {
+      applyTrackLinks(null);
+    }
+    return track;
   }
 
   function createLinkControl(link){
@@ -580,19 +694,23 @@ function openModal(p){
       btn.className = 'wk-chip';
       btn.textContent = link.label;
       btn.addEventListener('click', ()=>{
-        if (link.trackTitle) highlightTrack(link.trackTitle);
-        setPreview(link.media, link.trackTitle || link.label, { fallback: link.thumb || p.thumb });
+        if (link.trackTitle){
+          showTrack(link.trackTitle, {
+            media: link.media,
+            label: link.trackTitle || link.label,
+            fallback: link.thumb || p.thumb,
+          });
+        } else {
+          setPreview(link.media, link.trackTitle || link.label, { fallback: link.thumb || p.thumb });
+          applyTrackLinks(null);
+        }
       });
       return btn;
     }
     return null;
   }
 
-  (p.links||[]).forEach(link => {
-    const el = createLinkControl(link);
-    if (el) linksEl.appendChild(el);
-  });
-  linksEl.hidden = !linksEl.childElementCount;
+  renderLinks(baseLinks);
 
   const defaultPreview = p.preview || p.media || ((p.thumb && p.thumb !== 'auto') ? { type: 'image', src: p.thumb } : null);
   setPreview(defaultPreview, p.title);
@@ -628,16 +746,11 @@ function openModal(p){
       }
       list.appendChild(btn);
 
-      const key = (t.title || '').trim().toLowerCase();
+      const key = keyFor(t.title);
       trackButtons.set(key, { button: btn, track: t });
 
       btn.addEventListener('click', ()=>{
-        highlightTrack(t.title);
-        if (t.media){
-          setPreview(t.media, t.title, { fallback: t.thumb });
-        } else {
-          setPreview(null, t.title, { fallback: t.thumb });
-        }
+        showTrack(t.title);
       });
     });
   } else {
@@ -674,36 +787,63 @@ async function loadMemoriesAlbum(){
   const album = PROJECTS.find(p => p.dataUrl === MEMORIES_DATA_URL);
   if (!album) return;
 
+  const setUrl = normalizeSoundCloudUrl(album.setUrl || MEMORIES_SET_CANONICAL || MEMORIES_SET_URL);
+  album.setUrl = setUrl || MEMORIES_SET_CANONICAL || MEMORIES_SET_URL;
+
   try {
     const res = await fetch(`${album.dataUrl}?v=${Date.now()}`, { cache: 'no-store' });
     if (!res.ok) throw new Error('memories-of-noise.json missing');
     const list = await res.json();
 
     const tracks = await Promise.all((list || []).map(async (track) => {
-      const scUrl = track.scUrl || '';
-      const youtubeUrl = track.youtubeUrl || '';
+      const rawScUrl = track.scUrl || '';
+      const youtubeUrl = (track.youtubeUrl || '').trim();
+      const listenUrl = normalizeSoundCloudUrl(rawScUrl, { keepParams: ['secret_token'] });
+      const embedUrl = normalizeSoundCloudUrl(listenUrl || rawScUrl, { contextUrl: setUrl });
       let thumb = track.thumb || '';
-      if (!thumb) thumb = await fetchSoundCloudThumb(scUrl);
+      if (!thumb) thumb = await fetchSoundCloudThumb(embedUrl || listenUrl);
+      if (!thumb && listenUrl && embedUrl && embedUrl !== listenUrl) {
+        thumb = await fetchSoundCloudThumb(listenUrl);
+      }
       return {
         title: track.title || 'Untitled',
         thumb: thumb || PLACEHOLDER,
-        scUrl,
+        scUrl: listenUrl,
+        listenUrl,
+        embedUrl,
         youtubeUrl,
-        media: scUrl ? { type: 'embed', src: scEmbed(scUrl) } : null,
+        media: embedUrl ? { type: 'embed', src: scEmbed(embedUrl) } : null,
         altMedia: youtubeUrl ? { type: 'embed', src: youtubeEmbed(youtubeUrl) } : null,
+        links: Array.isArray(track.links) ? track.links.map(l => ({ ...l })) : [],
       };
     }));
 
     album.children = tracks;
 
-    const cover = (await fetchSoundCloudThumb(album.setUrl || MEMORIES_SET_URL)) || tracks[0]?.thumb;
+    const coverSource = setUrl || MEMORIES_SET_CANONICAL || MEMORIES_SET_URL;
+    const cover = (await fetchSoundCloudThumb(coverSource)) || tracks[0]?.thumb;
     if (cover) {
       album.thumb = cover;
       album.preview = { type: 'image', src: cover };
     }
 
-    if (!album.media && album.setUrl) {
+    if (setUrl) {
+      album.media = { type: 'embed', src: scEmbed(setUrl) };
+    } else if (!album.media && album.setUrl) {
       album.media = { type: 'embed', src: scEmbed(album.setUrl) };
+    }
+
+    const viewSetHref = setUrl || MEMORIES_SET_CANONICAL || MEMORIES_SET_URL;
+    if (viewSetHref) {
+      let links = Array.isArray(album.links) ? album.links.map(link => ({ ...link })) : [];
+      links = links.filter(link => (link.label || '').trim().toLowerCase() !== 'listen (soundcloud set)');
+      const existingIndex = links.findIndex(link => (link.label || '').trim().toLowerCase() === 'view set');
+      if (existingIndex >= 0) {
+        links[existingIndex] = { ...links[existingIndex], label: 'View set', href: viewSetHref };
+      } else {
+        links = [{ label: 'View set', href: viewSetHref }, ...links];
+      }
+      album.links = links;
     }
 
     const mvTrack = tracks.find(t => t.youtubeUrl);


### PR DESCRIPTION
## Summary
- normalize SoundCloud URLs before building embeds so playlist tracks resolve reliably
- refresh the Memories of Noise modal to surface a track-level Listen link while keeping the View set action pointed at the album playlist

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cfc8f2c4cc832fa24c4a046ffadabe