### PR TITLE
Add Back to Work modal link and responsive tweaks

### DIFF
--- a/work-test.html
+++ b/work-test.html
@@ -79,6 +79,23 @@
     .wk-chip:focus-visible{ outline:2px solid rgba(255,255,255,.35); outline-offset:2px; }
     button.wk-chip{ font:inherit; }
 
+    .wk-back{
+      border:1px solid var(--line);
+      background:var(--chip);
+      color:#fff;
+      font-size:12px;
+      padding:6px 10px;
+      border-radius:6px;
+      text-decoration:none;
+      display:inline-flex;
+      align-items:center;
+      gap:6px;
+      width:max-content;
+      transition:background .12s ease, border-color .12s ease;
+    }
+    .wk-back:hover{ background:var(--chipHover); border-color:#fff; }
+    .wk-back:focus-visible{ outline:2px solid rgba(255,255,255,.35); outline-offset:2px; }
+
     /* Modal */
     .wk-modal{ position:fixed; inset:0; display:none; align-items:center; justify-content:center; z-index:10000; }
     .wk-modal[open]{ display:flex; }
@@ -124,6 +141,11 @@
 
     .wk-close{ position:absolute; top:10px; right:10px; border:1px solid var(--line); background:var(--chip); color:#fff; border-radius:8px; padding:6px 9px; cursor:pointer; font-size:13px; }
     .wk-close:hover{ background:var(--chipHover); border-color:#fff; }
+
+    @media (max-width:480px){
+      .wk-detail{ padding-top:42px; }
+      .wk-close{ position:sticky; top:8px; margin-left:auto; }
+    }
   </style>
 </head>
 
@@ -160,6 +182,7 @@
       <div class="wk-preview" id="wkPreview"></div>
       <div class="wk-detail">
         <button class="wk-close" data-close>Close</button>
+        <a class="wk-back" href="#wkGrid" data-close>Back to Work</a>
         <h3 id="wkTitle">Title</h3>
         <p id="wkDesc"></p>
         <div class="wk-row" id="wkLinks"></div>


### PR DESCRIPTION
## Summary
- add a "Back to Work" link inside the work modal and style it to match the UI
- tweak the modal CSS for small screens by giving the detail area more top padding and making the close button sticky

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cfc923114c832f93c32831739eeed3