### PR TITLE
Update project media links and thumbnail info

### DIFF
--- a/work-test.html
+++ b/work-test.html
@@ -223,11 +223,11 @@ let PROJECTS = [
     title: "The Call Below",
     kind: "solo",
     thumb: "auto",
-    media: { type: "embed", src: scEmbed("https://soundcloud.com/thirty_3/the-call-below") },
+    media: { type: "embed", src: youtubeEmbed("https://youtu.be/Y_YEgEOXtAM") },
     desc: "Single released on Bandcamp.",
     links: [
       { label: "Listen (SoundCloud)", href: "https://soundcloud.com/thirty_3/the-call-below" },
-      { label: "Watch (YouTube)", action: "preview", media: { type: "embed", src: youtubeEmbed("https://youtu.be/Y_YEgEOXtAM") }, showOnCard: false },
+      { label: "Watch (YouTube)", href: "https://youtu.be/Y_YEgEOXtAM" },
       { label: "View on Bandcamp", href: "https://thirty3.bandcamp.com/track/the-call-below" }
     ]
   },
@@ -235,11 +235,12 @@ let PROJECTS = [
     title: "Mislay (feat. Lidnesty)",
     kind: "solo",
     thumb: "auto",
-    media: { type: "embed", src: scEmbed("https://soundcloud.com/thirty_3/mislay-feat-lidnesty") },
-    desc: "Single featuring Lidnesty, also part of Memories of Noise.",
+    media: { type: "embed", src: youtubeEmbed("https://youtu.be/tV5tmkoVEO0") },
+    desc: "From the 'Memories of Noise' series.",
     links: [
       { label: "Listen (SoundCloud)", href: "https://soundcloud.com/thirty_3/mislay-feat-lidnesty" },
-      { label: "Watch (YouTube)", action: "preview", media: { type: "embed", src: youtubeEmbed("https://youtu.be/tV5tmkoVEO0") }, showOnCard: false }
+      { label: "Watch (YouTube)", href: "https://youtu.be/tV5tmkoVEO0" },
+      { label: "View set", href: "https://soundcloud.com/thirty_3/sets/memories-of-noise" }
     ]
   },
   {
@@ -341,6 +342,7 @@ let PROJECTS = [
     title: "Mitsubishi Facelift — N I T E F I S H",
     kind: "collab",
     thumb: "auto",
+    scUrl: "https://soundcloud.com/nitefishofficial/mitsubishi-facelift",
     media: { type: "embed", src: scEmbed("https://soundcloud.com/nitefishofficial/mitsubishi-facelift") },
     desc: "Produced · Mixed · Mastered by THIRTY3.",
     links: [


### PR DESCRIPTION
## Summary
- switch The Call Below modal to the YouTube embed and expose the watch link on the card
- update Mislay to preview the YouTube video, refresh the description, and link back to the Memories of Noise set
- tag Mitsubishi Facelift with its SoundCloud URL so the hi-res thumbnail loader can pull the correct cover art

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfd267cd30832fb06863056a5d18af