### PR TITLE
Add subtle glitch hover to top navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,30 +56,6 @@
       .intro{ font-size:14px; }
       .mobile-overlay{ font-size:13px; }
     }
-    .topbar nav a{
-      transition: background .15s ease, border-color .15s ease, color .15s ease, transform .15s ease;
-    }
-
-    .topbar nav a:hover{
-      background: var(--chipHover);
-      border-color: #fff;
-    }
-
-    /* subtle glitch on hover (desktop only) */
-    @media (min-width: 480px){
-      @keyframes tiny-glitch {
-        0% { transform: translate(0,0); }
-        20% { transform: translate(.5px,-.5px); }
-        40% { transform: translate(-.5px,.5px); }
-        60% { transform: translate(.3px,0); }
-        100% { transform: translate(0,0); }
-      }
-      .topbar nav a:hover{ animation: tiny-glitch .25s steps(2,end) 2; }
-    }
-
-    /* Säkerställ att kontaktlänken alltid är klickbar överst */
-    .topbar nav a[href^="mailto:"]{ border-color: var(--chipBorder); }
-    .topbar nav a[href^="mailto:"]:hover{ background: var(--chipHover); }
     #logo3d-wrap{ position:fixed; left:12px; top:8px; width:84px; height:84px; z-index:10001; pointer-events:none; }
     #logo3d{ width:100%; height:100%; display:block; }
     @media (max-width:600px){ #logo3d-wrap{ left:8px; top:8px; width:64px; height:64px; } }
@@ -104,12 +80,12 @@
   <!-- Top bar -->
   <header class="topbar">
     <nav aria-label="Primary">
-      <a href="https://www.instagram.com/_thirty3_/" target="_blank" rel="noopener">INSTAGRAM</a>
-      <a href="https://soundcloud.com/thirty_3" target="_blank" rel="noopener">SOUNDCLOUD</a>
-      <a href="https://www.youtube.com/@thirty3473" target="_blank" rel="noopener">YOUTUBE</a>
-      <a href="work-test.html">WORK</a>
+      <a href="https://www.instagram.com/_thirty3_/" target="_blank" rel="noopener"><span class="nav-label">INSTAGRAM</span></a>
+      <a href="https://soundcloud.com/thirty_3" target="_blank" rel="noopener"><span class="nav-label">SOUNDCLOUD</span></a>
+      <a href="https://www.youtube.com/@thirty3473" target="_blank" rel="noopener"><span class="nav-label">YOUTUBE</span></a>
+      <a href="work-test.html"><span class="nav-label">WORK</span></a>
       <!-- Öppnar mailklient direkt -->
-      <a href="mailto:thirty3contact@gmail.com" aria-label="Email THIRTY3">CONTACT</a>
+      <a href="mailto:thirty3contact@gmail.com" aria-label="Email THIRTY3"><span class="nav-label">CONTACT</span></a>
     </nav>
   </header>
   <div id="logo3d-wrap"><canvas id="logo3d"></canvas></div>

--- a/style.css
+++ b/style.css
@@ -76,13 +76,92 @@ html, body{
   z-index:10000;
 }
 .topbar nav a{
-  all:unset; cursor:pointer;
+  all:unset;
+  cursor:pointer;
+  position:relative;
   color:#dfe4e6;
-  font-weight:600; font-size:13px; letter-spacing:.08em;
-  padding:6px 0; line-height:1;
-  transition:color .15s ease;
+  font-weight:600;
+  font-size:13px;
+  letter-spacing:.08em;
+  padding:6px 14px;
+  line-height:1;
+  border:1px solid var(--chipBorder);
+  border-radius:999px;
+  background:var(--chip);
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  overflow:hidden;
+  transition:background .18s ease, border-color .18s ease, color .18s ease;
 }
-.topbar nav a:hover{ color:#fff; }
+
+.topbar nav a::after{
+  content:"";
+  position:absolute;
+  left:12%;
+  right:12%;
+  height:2px;
+  top:0;
+  background:linear-gradient(90deg, transparent 0%, rgba(255,255,255,.45) 50%, transparent 100%);
+  opacity:0;
+  transform:translateY(-140%);
+  pointer-events:none;
+  z-index:0;
+}
+
+.topbar nav a .nav-label{
+  display:inline-block;
+  position:relative;
+  z-index:1;
+  transition:color .18s ease;
+}
+
+.topbar nav a:hover,
+.topbar nav a:focus-visible,
+.topbar nav a:active{
+  background:var(--chipHover);
+  border-color:#fff;
+  color:#fff;
+}
+
+.topbar nav a:focus-visible{
+  box-shadow:0 0 0 1px rgba(255,255,255,.35);
+}
+
+@media (hover:hover){
+  .topbar nav a:hover .nav-label,
+  .topbar nav a:focus-visible .nav-label{
+    animation:navMicroGlitch 90ms steps(2, end) 1;
+  }
+
+  .topbar nav a:hover::after,
+  .topbar nav a:focus-visible::after{
+    animation:navScan 90ms linear 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce){
+  .topbar nav a:hover .nav-label,
+  .topbar nav a:focus-visible .nav-label,
+  .topbar nav a:hover::after,
+  .topbar nav a:focus-visible::after{
+    animation:none !important;
+  }
+}
+
+@keyframes navMicroGlitch{
+  0%{ transform:translate3d(0,0,0); }
+  45%{ transform:translate3d(1px,0,0); }
+  55%{ transform:translate3d(-1px,0,0); }
+  100%{ transform:translate3d(0,0,0); }
+}
+
+@keyframes navScan{
+  0%{ opacity:0; transform:translateY(-140%); }
+  45%{ opacity:.35; transform:translateY(-20%); }
+  60%{ opacity:.3; transform:translateY(30%); }
+  100%{ opacity:0; transform:translateY(140%); }
+}
 
 /* ge plats under topbaren */
 body.home{ padding-top:56px; }
@@ -90,7 +169,7 @@ body.home{ padding-top:56px; }
 @media (max-width:480px){
   .topbar{ height:52px; }
   .topbar nav{ gap:16px; top:10px; }
-  .topbar nav a{ font-size:11px; letter-spacing:.06em; padding:6px 0; }
+  .topbar nav a{ font-size:11px; letter-spacing:.06em; padding:5px 8px; }
   #logo3d-wrap{ left:10px; top:4px; width:100px; height:48px; }
 }
 


### PR DESCRIPTION
## Summary
- give every topbar link the same chip-style hover/focus treatment and wrap the text so the animation can target it cleanly
- add a quick glitch + scan-line hover animation with a reduced-motion fallback

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cfdf9bb2b4832fa4bc27bcec92bd11