### PR TITLE
chore: remove 3D logo (Three.js), keep static background, and raise top navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,9 +56,6 @@
       .intro{ font-size:14px; }
       .mobile-overlay{ font-size:13px; }
     }
-    #logo3d-wrap{ position:fixed; left:12px; top:8px; width:84px; height:84px; z-index:10001; pointer-events:none; }
-    #logo3d{ width:100%; height:100%; display:block; }
-    @media (max-width:600px){ #logo3d-wrap{ left:8px; top:8px; width:64px; height:64px; } }
     /* ”Tap to open”-lagret */
     .mobile-overlay{
       position:absolute; inset:0;
@@ -69,10 +66,6 @@
       user-select:none;
     }
     .show-mobile-overlay .mobile-overlay{ display:flex; }
-
-    #logo3d-wrap{ position:fixed; left:12px; top:8px; width:84px; height:84px; z-index:10001; pointer-events:none; }
-    #logo3d{ width:100%; height:100%; display:block; }
-    @media (max-width:600px){ #logo3d-wrap{ left:8px; top:8px; width:64px; height:64px; } }
   </style>
 </head>
 
@@ -88,10 +81,6 @@
       <a href="mailto:thirty3contact@gmail.com" aria-label="Email THIRTY3"><span class="nav-label">CONTACT</span></a>
     </nav>
   </header>
-  <div id="logo3d-wrap"><canvas id="logo3d"></canvas></div>
-
-  <div id="logo3d-wrap"><canvas id="logo3d"></canvas></div>
-
   <!-- Background video + overlay -->
   <main>
     <div class="video-wrapper">
@@ -173,77 +162,5 @@
     window.addEventListener('DOMContentLoaded', ()=> glitchAndShow(document.querySelector('.glitch-title')));
   </script>
 
-  <!-- 3D LOGO (Three.js + OBJLoader) -->
-  <script src="https://unpkg.com/three@0.159.0/build/three.min.js"></script>
-  <script src="https://unpkg.com/three@0.159.0/examples/js/loaders/OBJLoader.js"></script>
-  <script>
-  (function () {
-    const cvs = document.getElementById('logo3d');
-    if (!cvs || !window.THREE) { console.warn('Three.js init skipped'); return; }
-
-    const renderer = new THREE.WebGLRenderer({ canvas: cvs, alpha: true, antialias: true });
-    if (!renderer.getContext()) { console.warn('Three.js renderer unavailable (no WebGL context)'); return; }
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
-
-    const scene = new THREE.Scene();
-    const cam = new THREE.PerspectiveCamera(35, 1, 0.1, 100);
-    cam.position.set(0.8, 0.6, 2.2);
-    scene.add(cam);
-
-    scene.add(new THREE.AmbientLight(0xffffff, 0.9));
-    const dir = new THREE.DirectionalLight(0xffffff, 1.0);
-    dir.position.set(2,2,3);
-    scene.add(dir);
-
-    const fallback = new THREE.Mesh(
-      new THREE.BoxGeometry(1,1,1),
-      new THREE.MeshStandardMaterial({ color:0xe7eceb, metalness:0.2, roughness:0.7 })
-    );
-    fallback.scale.setScalar(0.6);
-    scene.add(fallback);
-
-    function resize(){
-      const w = cvs.clientWidth || 84;
-      const h = cvs.clientHeight || 84;
-      renderer.setSize(w, h, false);
-      cam.aspect = w/h; cam.updateProjectionMatrix();
-    }
-    resize(); window.addEventListener('resize', resize);
-
-    function fitAndCenter(obj, target = 1.2){
-      const box = new THREE.Box3().setFromObject(obj);
-      const size = box.getSize(new THREE.Vector3());
-      const maxDim = Math.max(size.x, size.y, size.z) || 1;
-      const center = box.getCenter(new THREE.Vector3());
-      obj.position.sub(center);
-      obj.scale.setScalar(target / maxDim);
-      obj.rotation.set(0.2, 0.6, 0.0);
-    }
-
-    const OBJ_URL = new URL('Thirty3_Live_Logo.obj', window.location.href).toString();
-    const loader = new THREE.OBJLoader();
-    let liveObj = null;
-
-    loader.load(OBJ_URL, (obj) => {
-      obj.traverse((m) => {
-        if (m.isMesh && !m.material) {
-          m.material = new THREE.MeshStandardMaterial({ color:0xe7eceb, metalness:0.25, roughness:0.6 });
-        }
-      });
-      fitAndCenter(obj);
-      scene.remove(fallback);
-      scene.add(obj);
-      liveObj = obj;
-    }, undefined, (err) => {
-      console.error('OBJ load error:', err); // fallback cube stays visible
-    });
-
-    (function tick(){
-      (liveObj || fallback).rotation.y += 0.01;
-      renderer.render(scene, cam);
-      requestAnimationFrame(tick);
-    })();
-  })();
-  </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -36,33 +36,28 @@ html, body{
 /* ===============================
    Header / Topbar (centrerad meny + horisontella linjer)
 =================================*/
-.topbar {
-  position: sticky;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 60px;
-  z-index: 3000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: linear-gradient(to bottom, rgba(0,0,0,.35), rgba(0,0,0,.05));
-  backdrop-filter: blur(2px);
-  -webkit-backdrop-filter: blur(2px);
+.topbar{
+  position:fixed;
+  top:0;
+  left:0;
+  right:0;
+  height:56px;
+  z-index:9999;
+  display:flex;
+  align-items:flex-start;
+  justify-content:center;
+  background:linear-gradient(to bottom, rgba(0,0,0,.35), rgba(0,0,0,.05));
+  backdrop-filter:blur(2px);
+  -webkit-backdrop-filter:blur(2px);
 }
-
-/* 3D-logga till vänster */
-#logo3d-wrap{
-  position:absolute; left:14px; top:6px;
-  width:120px; height:56px; z-index:10001;
-  pointer-events:none;
-}
-#logo3d{ width:100%; height:100%; display:block; }
 
 /* Meny i mitten */
 .topbar nav{
-  position:absolute; left:50%; top:14px; transform:translateX(-50%);
-  display:flex; gap:28px; align-items:center;
+  display:flex;
+  gap:28px;
+  align-items:center;
+  margin:0;
+  padding:6px 0;
   z-index:10000;
 }
 .topbar nav a{
@@ -123,14 +118,26 @@ html, body{
   100%{ transform:translate(0,0); }
 }
 
-/* ge plats under topbaren */
-body.home{ padding-top:56px; }
+/* ge plats under topbaren + bakgrundsbild */
+body.home{
+  padding-top:56px;
+  background-color:#0b0e10;
+  background-image:url("image00015.jpeg");
+  background-repeat:no-repeat;
+  background-position:center;
+  background-size:cover;
+  background-attachment:fixed;
+}
+
+@media (max-width:768px){
+  body.home{ background-attachment:scroll; }
+}
 
 @media (max-width:480px){
   .topbar{ height:52px; }
-  .topbar nav{ gap:16px; top:10px; }
+  .topbar nav{ gap:16px; padding:8px 0 6px; }
   .topbar nav a{ font-size:11px; letter-spacing:.06em; padding:5px 8px; }
-  #logo3d-wrap{ left:10px; top:4px; width:100px; height:48px; }
+  body.home{ padding-top:52px; }
 }
 
 /* ===============================
@@ -320,10 +327,7 @@ body.work{ overflow-y:auto; background:#000; }
   .about-bio{ margin:0 auto; }
 }
 @media (max-width:700px){
-  .topbar{ height:50px; }
-  .topbar nav{ gap:14px; top:10px; }
+  .topbar nav{ gap:14px; }
   .topbar nav a{ font-size:12px; }
-  #logo3d-wrap{ display:none; } /* dölj 3D-logga på små skärmar */
-  body.home{ padding-top:50px; }
   body.about #about{ padding:90px 6vw 56px; }
 }


### PR DESCRIPTION
## Summary
- remove the home page's 3D logo canvas and the Three.js/OBJLoader scripts
- apply the static cover background image with the mobile attachment tweak
- reposition the fixed topbar nearer the viewport edge and update body padding to match

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d0faa3e2d8832f982f461516ba5d44