### PR TITLE
Remove nav glitch effects and relocate Mitsubishi Facelift collab

### DIFF
--- a/data/memories-of-noise.json
+++ b/data/memories-of-noise.json
@@ -42,12 +42,6 @@
     "thumb": ""
   },
   {
-    "title": "Mitsubishi Facelift — N I T E F I S H",
-    "scUrl": "https://soundcloud.com/nitefishofficial/mitsubishi-facelift",
-    "youtubeUrl": "",
-    "thumb": ""
-  },
-  {
     "title": "Radiant Desire",
     "scUrl": "https://soundcloud.com/thirty_3/radiant-desire",
     "youtubeUrl": "",

--- a/index.html
+++ b/index.html
@@ -157,9 +157,6 @@
       setTimeout(enableVideo, 1200);
     }
 
-    // Små glitch-effekter när sidan laddas
-    function glitchAndShow(el){ el.classList.add('glitching'); setTimeout(()=> el.classList.remove('glitching'), 600); }
-    window.addEventListener('DOMContentLoaded', ()=> glitchAndShow(document.querySelector('.glitch-title')));
   </script>
 
 </body>

--- a/style.css
+++ b/style.css
@@ -77,7 +77,8 @@ html, body{
   align-items:center;
   justify-content:center;
   overflow:hidden;
-  transition:background .18s ease, border-color .18s ease, color .18s ease;
+  transition:background .15s ease, color .15s ease, border-color .15s ease;
+  transform:none;
 }
 
 .topbar nav a .nav-label{
@@ -88,6 +89,7 @@ html, body{
 }
 
 .topbar nav a:hover,
+.topbar nav a:focus,
 .topbar nav a:focus-visible,
 .topbar nav a:active{
   background:var(--chipHover);
@@ -95,27 +97,8 @@ html, body{
   color:#fff;
 }
 
-.topbar nav a:hover,
-.topbar nav a:focus-visible{
-  animation:topbarGlitch .18s linear;
-}
-
 .topbar nav a:focus-visible{
   box-shadow:0 0 0 1px rgba(255,255,255,.35);
-}
-
-@media (prefers-reduced-motion: reduce){
-  .topbar nav a:hover,
-  .topbar nav a:focus-visible{
-    animation:none !important;
-  }
-}
-
-@keyframes topbarGlitch{
-  0%{ transform:translate(0,0); }
-  33%{ transform:translate(.3px,-.4px); }
-  66%{ transform:translate(-.4px,.3px); }
-  100%{ transform:translate(0,0); }
 }
 
 /* ge plats under topbaren + bakgrundsbild */

--- a/work-test.html
+++ b/work-test.html
@@ -39,10 +39,18 @@
       appearance:none; border:1px solid var(--line); background:var(--chip);
       color:#fff; font-size:13px; letter-spacing:.06em; font-weight:600;
       padding:8px 12px; border-radius:4px; cursor:pointer;
-      transition:transform .12s ease, background .12s ease, border-color .12s ease;
+      transition:background .15s ease, color .15s ease, border-color .15s ease, opacity .15s ease;
+      transform:none;
     }
-    .wk-tab[aria-pressed="true"]{ background:var(--chipHover); border-color:#fff; }
-    .wk-tab:hover{ transform:translateY(-1px); }
+    .wk-tab[aria-pressed="true"]{ background:var(--chipHover); border-color:#fff; color:#fff; }
+    .wk-tab:hover,
+    .wk-tab:focus,
+    .wk-tab:focus-visible{
+      background:var(--chipHover);
+      border-color:#fff;
+      color:#fff;
+      opacity:1;
+    }
 
     /* Grid */
     .wk-grid{ max-width:1100px; margin:0 auto 64px; padding:0 20px; display:grid; grid-template-columns:repeat(3, 1fr); gap:16px; }
@@ -72,13 +80,21 @@
       padding:6px 10px;
       border-radius:4px;
       text-decoration:none;
-      transition:background .12s ease, border-color .12s ease;
+      transition:background .15s ease, color .15s ease, border-color .15s ease, opacity .15s ease;
+      transform:none;
       display:inline-flex;
       align-items:center;
       gap:6px;
       cursor:pointer;
     }
-    .wk-chip:hover{ background:var(--chipHover); border-color:#fff; }
+    .wk-chip:hover,
+    .wk-chip:focus,
+    .wk-chip:focus-visible{
+      background:var(--chipHover);
+      color:#fff;
+      border-color:#fff;
+      opacity:1;
+    }
     .wk-chip:focus-visible{ outline:2px solid rgba(255,255,255,.35); outline-offset:2px; }
     button.wk-chip{ font:inherit; }
 
@@ -253,8 +269,21 @@
     .track-row .title{ flex:1; font-size:13px; letter-spacing:.03em; color:var(--ink); }
     .track-row .badge{ font-size:10px; letter-spacing:.12em; text-transform:uppercase; border:1px solid var(--line); border-radius:999px; padding:2px 6px; background:rgba(255,255,255,.08); color:var(--ink); }
 
-    .wk-close{ border:1px solid var(--line); background:var(--chip); color:#fff; border-radius:8px; padding:6px 10px; cursor:pointer; font-size:13px; margin-left:auto; }
-    .wk-close:hover{ background:var(--chipHover); border-color:#fff; }
+    .wk-close{
+      border:1px solid var(--line);
+      background:var(--chip);
+      color:#fff;
+      border-radius:8px;
+      padding:6px 10px;
+      cursor:pointer;
+      font-size:13px;
+      margin-left:auto;
+      transition:background .15s ease, color .15s ease, border-color .15s ease, opacity .15s ease;
+      transform:none;
+    }
+    .wk-close:hover,
+    .wk-close:focus,
+    .wk-close:focus-visible{ background:var(--chipHover); border-color:#fff; color:#fff; opacity:1; }
   </style>
 </head>
 
@@ -501,14 +530,16 @@ let PROJECTS = [
     links: [ { label: "Watch (YouTube)", href: "https://www.youtube.com/watch?v=o9cvorFHGos" } ]
   },
   {
-    title: "Mitsubishi Facelift — N I T E F I S H",
+    title: "Mitsubishi Facelift — N I T E F I S H (ft. Thirty3)",
     kind: "collab",
     thumb: "auto",
     scUrl: "https://soundcloud.com/nitefishofficial/mitsubishi-facelift",
-    media: { type: "embed", src: scEmbed("https://soundcloud.com/nitefishofficial/mitsubishi-facelift") },
-    desc: "Produced · Mixed · Mastered by THIRTY3.",
+    media: {
+      type: "embed",
+      src: "https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/nitefishofficial/mitsubishi-facelift&visual=true"
+    },
+    desc: "Collaboration single with N I T E F I S H.",
     links: [
-      { label: "Read (Kmag article)", href: "https://kmag.se/2024/06/09/n-i-t-e-f-i-s-h-slapper-singeln-mitsubishi-facelift-fran-kommande-ep/" },
       { label: "Listen (SoundCloud)", href: "https://soundcloud.com/nitefishofficial/mitsubishi-facelift" }
     ]
   },


### PR DESCRIPTION
## Summary
- replace the glitch-style animation on the top navigation, work tabs, and chips with smooth hover fill treatments
- remove "Mitsubishi Facelift" from the Memories of Noise track data
- add Mitsubishi Facelift as a collab entry with a visual SoundCloud embed in the work grid

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d0ff86ee14832fb016f6df7f7031f5