### PR TITLE
Add MusicGroup schema.org sameAs structured data

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,24 @@
     }
     .show-mobile-overlay .mobile-overlay{ display:flex; }
   </style>
+  <!-- Structured data: link all official profiles for SEO/Knowledge Graph -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "MusicGroup",
+    "name": "THIRTY3",
+    "alternateName": ["Thirty3"],
+    "url": "https://thirty3music.github.io/thirty3-site/",
+    "sameAs": [
+      "https://soundcloud.com/thirty_3",
+      "https://www.instagram.com/_thirty3_/",
+      "https://www.youtube.com/@thirty3473",
+      "https://thirty3.bandcamp.com/",
+      "https://ra.co/dj/thirty3",
+      "https://open.spotify.com/artist/5ysVz3lhJomLapuhp6WVaQ?si=2PlmlrqQR8qdObD_O2Qe4w"
+    ]
+  }
+  </script>
 </head>
 
 <body class="home">


### PR DESCRIPTION
## Summary
- add a schema.org MusicGroup JSON-LD block to expose official profiles for THIRTY3

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d43006ea88832fb3d3068c8e33cf5d