### PR TITLE
Add events listing to Work page

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -1,0 +1,18 @@
+[
+  {
+    "date": "2025-02-15",
+    "title": "Samoota — In the Shadow of Three Suns (Exhibition, afterparty DJ: Thirty3)",
+    "venue": "Indra Gallery",
+    "city": "London",
+    "source": "Trip",
+    "url": "https://www.trip.com/events/samoota-in-the-shadow-of-three-suns--art-gallery--exhibition-20250120/"
+  },
+  {
+    "date": "2024-11-16",
+    "title": "Thirty3 (DJ)",
+    "venue": "Example Club",
+    "city": "Stockholm",
+    "source": "RA",
+    "url": "https://ra.co/events/1234567"
+  }
+]

--- a/scripts/events.js
+++ b/scripts/events.js
@@ -1,0 +1,37 @@
+(async function(){
+  const wrap = document.querySelector('#events-wrap');
+  if(!wrap) return;
+  const res = await fetch('data/events.json');
+  const all = await res.json();
+
+  const today = new Date().toISOString().slice(0,10);
+  const upcoming = all.filter(e => e.date >= today)
+                      .sort((a,b)=> a.date.localeCompare(b.date));
+  const past = all.filter(e => e.date < today)
+                  .sort((a,b)=> b.date.localeCompare(a.date));
+
+  function f(d){
+    const dt = new Date(d+'T12:00:00');
+    return dt.toLocaleDateString('en-GB',{day:'2-digit',month:'short',year:'numeric'});
+  }
+
+  function row(e){
+    return `
+      <li class="evt">
+        <span class="d">${f(e.date)}</span>
+        <span class="t">${e.title}</span>
+        <span class="v">${e.venue}${e.city? ' — '+e.city:''}</span>
+        <a class="lnk" href="${e.url}" target="_blank" rel="noopener">View</a>
+      </li>`;
+  }
+
+  wrap.innerHTML = `
+    <div class="events-head">
+      <h3 class="events-title">Events</h3>
+      <a class="chip" href="https://ra.co/dj/thirty3" target="_blank" rel="noopener">View all on RA</a>
+    </div>
+    <ul class="events-list">${upcoming.map(row).join('') || '<li class="muted">No upcoming events yet.</li>'}</ul>
+    <details class="events-past"><summary>Past events</summary>
+      <ul class="events-list past">${past.map(row).join('') || '<li class="muted">—</li>'}</ul>
+    </details>`;
+})();

--- a/style.css
+++ b/style.css
@@ -142,6 +142,28 @@ body.home{
   }
 }
 
+#events{ margin:16px 0 24px; }
+.events-head{ display:flex; gap:10px; align-items:center; justify-content:space-between; }
+.events-title{ color:#79e6e0; letter-spacing:.04em; font-weight:600; }
+.chip{
+  display:inline-block; font-size:12px; padding:6px 10px;
+  border:1px solid rgba(255,255,255,.2); border-radius:999px;
+  background:rgba(0,0,0,.35); color:#ddd; text-decoration:none;
+}
+.events-list{ list-style:none; margin:8px 0 0; padding:0; }
+.muted{ color:#9aa3aa; font-style:italic; }
+.evt{ display:grid; grid-template-columns:120px 1fr auto auto; gap:10px;
+     padding:10px 12px; border:1px solid rgba(255,255,255,.08); border-radius:8px;
+     background:rgba(0,0,0,.25); margin-bottom:8px; align-items:center; }
+.evt .d{ font-variant-numeric:tabular-nums; color:#cfd4d8; }
+.evt .t{ color:#e9ecef; }
+.evt .v{ color:#9aa3aa; }
+.evt .lnk{ justify-self:end; font-size:12px; border:1px solid rgba(255,255,255,.2);
+  padding:6px 10px; border-radius:6px; color:#e7e7e7; text-decoration:none; }
+.events-past summary{ cursor:pointer; margin-top:10px; color:#aeb7bd; }
+@media(max-width:600px){ .evt{ grid-template-columns:110px 1fr; }
+  .evt .v{ grid-column:1 / -2; } .evt .lnk{ grid-column:-2 / -1; } }
+
 /* ===============================
    Hero / content
 =================================*/

--- a/work-test.html
+++ b/work-test.html
@@ -336,6 +336,10 @@
     </div>
   </section>
 
+  <section id="events" aria-label="Events">
+    <div id="events-wrap"></div>
+  </section>
+
   <section class="wk-grid" id="wkGrid" aria-live="polite"></section>
 
   <dialog class="wk-modal" id="wkModal">
@@ -353,6 +357,8 @@
       </div>
     </div>
   </dialog>
+
+  <script src="scripts/events.js"></script>
 
   <script>
 /* =========================================================


### PR DESCRIPTION
## Summary
- add an events data file and loader script to power the Work page events section
- insert the upcoming and past events block with a link to Resident Advisor
- style the events list and chip for desktop and mobile layouts

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e144118fe8832fa350db8f84eb9ff7