### PR TITLE
Add new events and refresh work page listings

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -1,18 +1,41 @@
 [
   {
-    "date": "2025-02-15",
     "title": "Samoota — In the Shadow of Three Suns (Exhibition, afterparty DJ: Thirty3)",
+    "subtitle": "",
+    "source": "trip",
+    "link": "https://www.trip.com/events/samoota-in-the-shadow-of-three-suns--art-gallery--exhibition-20250120/",
     "venue": "Indra Gallery",
     "city": "London",
-    "source": "Trip",
-    "url": "https://www.trip.com/events/samoota-in-the-shadow-of-three-suns--art-gallery--exhibition-20250120/"
+    "country": "United Kingdom",
+    "tags": ["Exhibition", "DJ"],
+    "date": "2025-02-15",
+    "time": "",
+    "performers": ["Thirty3"]
   },
   {
-    "date": "2024-11-16",
-    "title": "Thirty3 (DJ)",
-    "venue": "Example Club",
+    "title": "Loops for Stagnation — Workshop & DJ set",
+    "subtitle": "KTH NAVET / for students",
+    "source": "kth",
+    "link": "https://www.kth.se/navet/for-students/student-led-activities/loops-for-stagnation-workshop-and-dj-set-1.1401240",
+    "venue": "KTH (Navet)",
     "city": "Stockholm",
-    "source": "RA",
-    "url": "https://ra.co/events/1234567"
+    "country": "Sweden",
+    "tags": ["Workshop", "DJ", "Live / AV"],
+    "date": "",
+    "time": "",
+    "performers": ["Thirty3"]
+  },
+  {
+    "title": "Thirty3 — RA Event",
+    "subtitle": "",
+    "source": "ra",
+    "link": "https://ra.co/events/2266481",
+    "venue": "",
+    "city": "",
+    "country": "",
+    "tags": ["Live / AV"],
+    "date": "",
+    "time": "",
+    "performers": ["Thirty3"]
   }
 ]

--- a/scripts/events.js
+++ b/scripts/events.js
@@ -4,24 +4,45 @@
   const res = await fetch('data/events.json');
   const all = await res.json();
 
-  const today = new Date().toISOString().slice(0,10);
-  const upcoming = all.filter(e => e.date >= today)
-                      .sort((a,b)=> a.date.localeCompare(b.date));
-  const past = all.filter(e => e.date < today)
-                  .sort((a,b)=> b.date.localeCompare(a.date));
+  const today = new Date().toISOString().slice(0, 10);
+  const trimmed = all.map(e => ({ ...e, date: (e.date || '').trim() }));
+  const upcoming = trimmed
+    .filter(e => !e.date || e.date >= today)
+    .sort((a, b) => {
+      if (!a.date && !b.date) return 0;
+      if (!a.date) return 1;
+      if (!b.date) return -1;
+      return a.date.localeCompare(b.date);
+    });
+  const past = trimmed
+    .filter(e => e.date && e.date < today)
+    .sort((a, b) => b.date.localeCompare(a.date));
 
-  function f(d){
-    const dt = new Date(d+'T12:00:00');
-    return dt.toLocaleDateString('en-GB',{day:'2-digit',month:'short',year:'numeric'});
+  function formatDate(d) {
+    const dt = new Date(`${d}T12:00:00`);
+    if (Number.isNaN(dt.getTime())) return '';
+    return dt.toLocaleDateString('en-GB', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+    });
   }
 
-  function row(e){
+  function row(e) {
+    const hasDate = Boolean(e.date);
+    const location = [e.venue, e.city, e.country].filter(Boolean).join(' — ');
+    const subtitle = e.subtitle ? `<p class="evt-sub">${e.subtitle}</p>` : '';
+    const meta = location ? `<p class="evt-meta">${location}</p>` : '';
+
     return `
       <li class="evt">
-        <span class="d">${f(e.date)}</span>
-        <span class="t">${e.title}</span>
-        <span class="v">${e.venue}${e.city? ' — '+e.city:''}</span>
-        <a class="lnk" href="${e.url}" target="_blank" rel="noopener">View</a>
+        ${hasDate ? `<span class="evt-badge">${formatDate(e.date)}</span>` : ''}
+        <div class="evt-body">
+          <h4 class="evt-title">${e.title}</h4>
+          ${subtitle}
+          ${meta}
+        </div>
+        <a class="evt-link" href="${e.link}" target="_blank" rel="noopener">View details</a>
       </li>`;
   }
 

--- a/style.css
+++ b/style.css
@@ -152,17 +152,26 @@ body.home{
 }
 .events-list{ list-style:none; margin:8px 0 0; padding:0; }
 .muted{ color:#9aa3aa; font-style:italic; }
-.evt{ display:grid; grid-template-columns:120px 1fr auto auto; gap:10px;
-     padding:10px 12px; border:1px solid rgba(255,255,255,.08); border-radius:8px;
-     background:rgba(0,0,0,.25); margin-bottom:8px; align-items:center; }
-.evt .d{ font-variant-numeric:tabular-nums; color:#cfd4d8; }
-.evt .t{ color:#e9ecef; }
-.evt .v{ color:#9aa3aa; }
-.evt .lnk{ justify-self:end; font-size:12px; border:1px solid rgba(255,255,255,.2);
-  padding:6px 10px; border-radius:6px; color:#e7e7e7; text-decoration:none; }
+.evt{ position:relative; display:flex; flex-direction:column; gap:12px;
+     padding:14px 16px; border:1px solid rgba(255,255,255,.08); border-radius:10px;
+     background:rgba(0,0,0,.25); margin-bottom:10px; }
+.evt-body{ display:flex; flex-direction:column; gap:6px; }
+.evt-title{ color:#e9ecef; font-size:16px; margin:0; }
+.evt-sub{ color:#cfd4d8; margin:0; font-size:14px; }
+.evt-meta{ color:#9aa3aa; margin:0; font-size:13px; letter-spacing:.01em; }
+.evt-link{ align-self:flex-start; font-size:12px; border:1px solid rgba(255,255,255,.2);
+  padding:6px 12px; border-radius:6px; color:#e7e7e7; text-decoration:none; background:rgba(0,0,0,.3); }
+.evt-link:hover{ border-color:rgba(121,230,224,.4); color:#79e6e0; }
+.evt-badge{ position:absolute; top:12px; right:16px; font-size:11px; letter-spacing:.04em;
+  padding:4px 8px; border-radius:999px; background:rgba(121,230,224,.15);
+  border:1px solid rgba(121,230,224,.4); color:#79e6e0; font-variant-numeric:tabular-nums; }
 .events-past summary{ cursor:pointer; margin-top:10px; color:#aeb7bd; }
-@media(max-width:600px){ .evt{ grid-template-columns:110px 1fr; }
-  .evt .v{ grid-column:1 / -2; } .evt .lnk{ grid-column:-2 / -1; } }
+@media(max-width:600px){
+  .evt{ padding:12px 14px; }
+  .evt-badge{ position:static; align-self:flex-end; margin-bottom:-4px; }
+  .evt{ gap:10px; }
+  .evt-link{ align-self:stretch; text-align:center; }
+}
 
 /* ===============================
    Hero / content


### PR DESCRIPTION
## Summary
- add the latest KTH Navet and Resident Advisor appearances to the events data
- remove the incorrect RA event entry and enrich existing listings with metadata
- update the work page events module to support the richer structure and refreshed styling

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e1482154d4832f87bceee89531da0c