### PR TITLE
Add updated events listings and schema metadata

### DIFF
--- a/style.css
+++ b/style.css
@@ -142,35 +142,20 @@ body.home{
   }
 }
 
-#events{ margin:16px 0 24px; }
-.events-head{ display:flex; gap:10px; align-items:center; justify-content:space-between; }
-.events-title{ color:#79e6e0; letter-spacing:.04em; font-weight:600; }
-.chip{
-  display:inline-block; font-size:12px; padding:6px 10px;
-  border:1px solid rgba(255,255,255,.2); border-radius:999px;
-  background:rgba(0,0,0,.35); color:#ddd; text-decoration:none;
-}
-.events-list{ list-style:none; margin:8px 0 0; padding:0; }
-.muted{ color:#9aa3aa; font-style:italic; }
-.evt{ position:relative; display:flex; flex-direction:column; gap:12px;
-     padding:14px 16px; border:1px solid rgba(255,255,255,.08); border-radius:10px;
-     background:rgba(0,0,0,.25); margin-bottom:10px; }
-.evt-body{ display:flex; flex-direction:column; gap:6px; }
-.evt-title{ color:#e9ecef; font-size:16px; margin:0; }
-.evt-sub{ color:#cfd4d8; margin:0; font-size:14px; }
-.evt-meta{ color:#9aa3aa; margin:0; font-size:13px; letter-spacing:.01em; }
-.evt-link{ align-self:flex-start; font-size:12px; border:1px solid rgba(255,255,255,.2);
-  padding:6px 12px; border-radius:6px; color:#e7e7e7; text-decoration:none; background:rgba(0,0,0,.3); }
-.evt-link:hover{ border-color:rgba(121,230,224,.4); color:#79e6e0; }
-.evt-badge{ position:absolute; top:12px; right:16px; font-size:11px; letter-spacing:.04em;
-  padding:4px 8px; border-radius:999px; background:rgba(121,230,224,.15);
-  border:1px solid rgba(121,230,224,.4); color:#79e6e0; font-variant-numeric:tabular-nums; }
-.events-past summary{ cursor:pointer; margin-top:10px; color:#aeb7bd; }
-@media(max-width:600px){
-  .evt{ padding:12px 14px; }
-  .evt-badge{ position:static; align-self:flex-end; margin-bottom:-4px; }
-  .evt{ gap:10px; }
-  .evt-link{ align-self:stretch; text-align:center; }
+.events{ margin-top:24px; }
+.events h3,
+.events .events-subhead{ color:var(--fg, #cfcfcf); margin:16px 0 12px; letter-spacing:.04em; }
+.event-card{ display:grid; grid-template-columns:1fr auto; gap:12px; padding:12px 14px; border:1px solid rgba(255,255,255,.08); border-radius:10px; background:rgba(0,0,0,.25); margin-bottom:10px; }
+.event-card .event-actions{ display:flex; align-items:flex-start; }
+.event-card .event-thumb img{ display:block; width:100%; max-width:420px; border-radius:8px; }
+.event-card.past{ grid-template-columns:240px 1fr auto; align-items:start; }
+.event-card .event-title{ margin:0 0 6px; letter-spacing:.06em; }
+.event-card .event-meta{ display:flex; gap:10px; font-size:13px; opacity:.8; flex-wrap:wrap; }
+.event-card .event-desc{ margin:0 0 10px; font-size:14px; opacity:.85; }
+.event-card .btn{ display:inline-block; padding:6px 10px; border:1px solid rgba(255,255,255,.25); border-radius:8px; text-decoration:none; color:inherit; }
+@media (max-width: 720px){
+  .event-card.past{ grid-template-columns:1fr; }
+  .event-card .event-thumb{ order:-1; }
 }
 
 /* ===============================

--- a/work-test.html
+++ b/work-test.html
@@ -5,23 +5,83 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>THIRTY3 — Work</title>
   <link rel="stylesheet" href="style.css"/>
+  <!-- JSON-LD: KTH Loops for Stagnation -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "Event",
-    "name": "Samoota — In the Shadow of Three Suns (Exhibition)",
-    "startDate": "2025-01-20",
+    "name": "Loops for Stagnation — Workshop & DJ set",
+    "startDate": "2025-05-09",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
     "eventStatus": "https://schema.org/EventScheduled",
-    "url": "https://www.trip.com/events/samoota-in-the-shadow-of-three-suns--art-gallery--exhibition-20250120/",
+    "location": {
+      "@type": "Place",
+      "name": "KTH NAVET",
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Stockholm",
+        "addressCountry": "SE"
+      }
+    },
     "performer": {
-      "@type": "Person",
+      "@type": "MusicGroup",
       "name": "THIRTY3"
     },
     "organizer": {
       "@type": "Organization",
-      "name": "Samoota"
-    }
+      "name": "KTH NAVET"
+    },
+    "url": "https://www.kth.se/navet/for-students/student-led-activities/loops-for-stagnation-workshop-and-dj-set-1.1401240"
+  }
+  </script>
+
+  <!-- JSON-LD: RA Event -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Event",
+    "name": "Thirty3 — RA Event",
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Stockholm",
+        "addressCountry": "SE"
+      }
+    },
+    "performer": {
+      "@type": "MusicGroup",
+      "name": "THIRTY3"
+    },
+    "url": "https://ra.co/events/2266481"
+  }
+  </script>
+
+  <!-- JSON-LD: Samoota -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Event",
+    "name": "Samoota — In the Shadow of Three Suns",
+    "startDate": "2025-02-15",
+    "eventStatus": "https://schema.org/EventCompleted",
+    "location": {
+      "@type": "Place",
+      "name": "Indra Gallery",
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "London",
+        "addressCountry": "GB"
+      }
+    },
+    "performer": [
+      { "@type": "Person", "name": "in-soo" },
+      { "@type": "MusicGroup", "name": "Sweeep" },
+      { "@type": "MusicGroup", "name": "THIRTY3" }
+    ],
+    "description": "Audiovisual exhibition by Petter Schiölander at Indra Gallery with afterparty DJ sets by in-soo, Sweeep & Thirty3.",
+    "url": "https://www.trip.com/events/samoota-in-the-shadow-of-three-suns--art-gallery--exhibition-20250120/"
   }
   </script>
 
@@ -336,8 +396,60 @@
     </div>
   </section>
 
-  <section id="events" aria-label="Events">
-    <div id="events-wrap"></div>
+  <!-- Events -->
+  <section id="events" class="events" aria-label="Events">
+    <h3>Events</h3>
+
+    <!-- KTH: Loops for Stagnation — Workshop & DJ set -->
+    <article class="event-card upcoming">
+      <div class="event-main">
+        <h4 class="event-title">Loops for Stagnation — Workshop &amp; DJ set</h4>
+        <div class="event-meta">
+          <span class="event-where">KTH NAVET — Stockholm, Sweden</span>
+          <span class="event-when" data-date="2025-05-09">09 May 2025</span>
+        </div>
+      </div>
+      <div class="event-actions">
+        <a class="btn" href="https://www.kth.se/navet/for-students/student-led-activities/loops-for-stagnation-workshop-and-dj-set-1.1401240" target="_blank" rel="noopener">View details</a>
+      </div>
+    </article>
+
+    <!-- RA: new event -->
+    <article class="event-card upcoming">
+      <div class="event-main">
+        <h4 class="event-title">Thirty3 — RA Event</h4>
+        <div class="event-meta">
+          <span class="event-where">Stockholm, Sweden</span>
+          <span class="event-when" data-date="">TBD</span>
+        </div>
+      </div>
+      <div class="event-actions">
+        <a class="btn" href="https://ra.co/events/2266481" target="_blank" rel="noopener">View on Resident Advisor</a>
+      </div>
+    </article>
+
+    <!-- Past events header -->
+    <h4 class="events-subhead">Past events</h4>
+
+    <!-- Samoota: past -->
+    <article class="event-card past">
+      <div class="event-thumb">
+        <img src="data/images/samoota-poster.jpg" alt="Samoota — In the Shadow of Three Suns" onerror="this.style.display='none'">
+      </div>
+      <div class="event-main">
+        <h4 class="event-title">Samoota — In the Shadow of Three Suns</h4>
+        <p class="event-desc">
+          Audiovisual exhibition by Petter Schiölander at Indra Gallery with afterparty DJ sets by in-soo, Sweeep &amp; Thirty3.
+        </p>
+        <div class="event-meta">
+          <span class="event-where">Indra Gallery — London, UK</span>
+          <span class="event-when" data-date="2025-02-15">15 Feb 2025</span>
+        </div>
+      </div>
+      <div class="event-actions">
+        <a class="btn" href="https://www.trip.com/events/samoota-in-the-shadow-of-three-suns--art-gallery--exhibition-20250120/" target="_blank" rel="noopener">View details</a>
+      </div>
+    </article>
   </section>
 
   <section class="wk-grid" id="wkGrid" aria-live="polite"></section>
@@ -357,8 +469,6 @@
       </div>
     </div>
   </dialog>
-
-  <script src="scripts/events.js"></script>
 
   <script>
 /* =========================================================


### PR DESCRIPTION
## Summary
- add a dedicated events section with updated upcoming and past entries, including the new KTH and Resident Advisor listings
- embed individual schema.org Event JSON-LD blocks for KTH, Resident Advisor, and Samoota
- refresh event card styling to match the new layout and metadata details

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68e14dbedf2c832fbe9e34eac674f8d7