### PR TITLE
Restyle Events section to match work cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -142,20 +142,99 @@ body.home{
   }
 }
 
-.events{ margin-top:24px; }
-.events h3,
-.events .events-subhead{ color:var(--fg, #cfcfcf); margin:16px 0 12px; letter-spacing:.04em; }
-.event-card{ display:grid; grid-template-columns:1fr auto; gap:12px; padding:12px 14px; border:1px solid rgba(255,255,255,.08); border-radius:10px; background:rgba(0,0,0,.25); margin-bottom:10px; }
-.event-card .event-actions{ display:flex; align-items:flex-start; }
-.event-card .event-thumb img{ display:block; width:100%; max-width:420px; border-radius:8px; }
-.event-card.past{ grid-template-columns:240px 1fr auto; align-items:start; }
-.event-card .event-title{ margin:0 0 6px; letter-spacing:.06em; }
-.event-card .event-meta{ display:flex; gap:10px; font-size:13px; opacity:.8; flex-wrap:wrap; }
-.event-card .event-desc{ margin:0 0 10px; font-size:14px; opacity:.85; }
-.event-card .btn{ display:inline-block; padding:6px 10px; border:1px solid rgba(255,255,255,.25); border-radius:8px; text-decoration:none; color:inherit; }
-@media (max-width: 720px){
-  .event-card.past{ grid-template-columns:1fr; }
-  .event-card .event-thumb{ order:-1; }
+.events{ margin-top:26px; }
+.events-title{
+  margin:0 0 10px;
+  font-size:15px;
+  letter-spacing:.08em;
+  color:var(--fg-subtle, #a9b0b3);
+  text-transform:uppercase;
+}
+
+.work-grid{
+  max-width:1100px;
+  margin:0 auto 64px;
+  padding:0 20px;
+}
+
+/* Grid – exakt samma som work-grid */
+.events-grid{
+  display:grid;
+  grid-template-columns:repeat(3, minmax(0,1fr));
+  gap:18px;
+}
+
+@media (max-width:900px){ .events-grid{ grid-template-columns:repeat(2, minmax(0,1fr)); } }
+@media (max-width:560px){ .events-grid{ grid-template-columns:1fr; } }
+
+/* Kort – matcha dina projektkort */
+.card.event-card{
+  background:var(--card-bg, rgba(0,0,0,.22));
+  border:1px solid rgba(255,255,255,.08);
+  border-radius:12px;
+  overflow:hidden;
+}
+
+/* Thumbnail */
+.thumb-wrap{ position:relative; }
+.thumb{
+  width:100%;
+  display:block;
+  aspect-ratio:16 / 9;
+  object-fit:cover;
+  background:rgba(255,255,255,.03);
+}
+.thumb--event{
+  background:linear-gradient(180deg, rgba(255,255,255,.05), rgba(255,255,255,.02));
+}
+
+/* Datum-badge (diskret) */
+.date-badge{
+  position:absolute;
+  top:10px;
+  right:10px;
+  font-size:11.5px;
+  line-height:1;
+  padding:4px 6px;
+  border:1px solid rgba(255,255,255,.14);
+  background:rgba(0,0,0,.35);
+  border-radius:6px;
+  letter-spacing:.04em;
+  opacity:.9;
+}
+
+/* Text – mindre & lugnare */
+.card-body{ padding:12px 12px 14px; }
+.card-title{
+  font-size:15px;
+  margin:0 0 6px;
+  letter-spacing:.04em;
+}
+.card-desc{
+  font-size:13px;
+  opacity:.85;
+  margin:0 0 6px;
+}
+.card-meta{
+  font-size:12.5px;
+  opacity:.7;
+  margin:0 0 10px;
+}
+
+/* Knapp – ghost, samma stil som dina små knappar */
+.btn.btn--ghost{
+  display:inline-block;
+  padding:6px 10px;
+  border:1px solid rgba(255,255,255,.2);
+  border-radius:8px;
+  text-decoration:none;
+  font-size:12.5px;
+  line-height:1;
+  transition:transform .12s ease, border-color .12s ease;
+}
+.btn.btn--ghost:hover{
+  transform:translateY(-1px);
+  border-color:rgba(255,255,255,.35);
 }
 
 /* ===============================

--- a/work-test.html
+++ b/work-test.html
@@ -397,59 +397,64 @@
   </section>
 
   <!-- Events -->
-  <section id="events" class="events" aria-label="Events">
-    <h3>Events</h3>
+  <section id="events" class="events">
+    <h3 class="events-title">Events</h3>
 
-    <!-- KTH: Loops for Stagnation — Workshop & DJ set -->
-    <article class="event-card upcoming">
-      <div class="event-main">
-        <h4 class="event-title">Loops for Stagnation — Workshop &amp; DJ set</h4>
-        <div class="event-meta">
-          <span class="event-where">KTH NAVET — Stockholm, Sweden</span>
-          <span class="event-when" data-date="2025-05-09">09 May 2025</span>
+    <!-- Grid som matchar work-korten -->
+    <div class="work-grid events-grid">
+      <!-- KTH -->
+      <article class="card event-card upcoming">
+        <div class="thumb-wrap">
+          <!-- valfri liten placeholder om du vill (eller lämna tomt) -->
+          <div class="thumb thumb--event" aria-hidden="true"></div>
+          <span class="date-badge">09 May 2025</span>
         </div>
-      </div>
-      <div class="event-actions">
-        <a class="btn" href="https://www.kth.se/navet/for-students/student-led-activities/loops-for-stagnation-workshop-and-dj-set-1.1401240" target="_blank" rel="noopener">View details</a>
-      </div>
-    </article>
-
-    <!-- RA: new event -->
-    <article class="event-card upcoming">
-      <div class="event-main">
-        <h4 class="event-title">Thirty3 — RA Event</h4>
-        <div class="event-meta">
-          <span class="event-where">Stockholm, Sweden</span>
-          <span class="event-when" data-date="">TBD</span>
+        <div class="card-body">
+          <h4 class="card-title">Loops for Stagnation — Workshop &amp; DJ set</h4>
+          <p class="card-meta">KTH NAVET — Stockholm, Sweden</p>
+          <a class="btn btn--ghost" target="_blank" rel="noopener"
+             href="https://www.kth.se/navet/for-students/student-led-activities/loops-for-stagnation-workshop-and-dj-set-1.1401240">
+            View details
+          </a>
         </div>
-      </div>
-      <div class="event-actions">
-        <a class="btn" href="https://ra.co/events/2266481" target="_blank" rel="noopener">View on Resident Advisor</a>
-      </div>
-    </article>
+      </article>
 
-    <!-- Past events header -->
-    <h4 class="events-subhead">Past events</h4>
-
-    <!-- Samoota: past -->
-    <article class="event-card past">
-      <div class="event-thumb">
-        <img src="data/images/samoota-poster.jpg" alt="Samoota — In the Shadow of Three Suns" onerror="this.style.display='none'">
-      </div>
-      <div class="event-main">
-        <h4 class="event-title">Samoota — In the Shadow of Three Suns</h4>
-        <p class="event-desc">
-          Audiovisual exhibition by Petter Schiölander at Indra Gallery with afterparty DJ sets by in-soo, Sweeep &amp; Thirty3.
-        </p>
-        <div class="event-meta">
-          <span class="event-where">Indra Gallery — London, UK</span>
-          <span class="event-when" data-date="2025-02-15">15 Feb 2025</span>
+      <!-- RA (TBD) -->
+      <article class="card event-card upcoming">
+        <div class="thumb-wrap">
+          <div class="thumb thumb--event" aria-hidden="true"></div>
+          <span class="date-badge">TBD</span>
         </div>
-      </div>
-      <div class="event-actions">
-        <a class="btn" href="https://www.trip.com/events/samoota-in-the-shadow-of-three-suns--art-gallery--exhibition-20250120/" target="_blank" rel="noopener">View details</a>
-      </div>
-    </article>
+        <div class="card-body">
+          <h4 class="card-title">Thirty3 — RA Event</h4>
+          <p class="card-meta">Stockholm, Sweden</p>
+          <a class="btn btn--ghost" target="_blank" rel="noopener"
+             href="https://ra.co/events/2266481">View on Resident Advisor</a>
+        </div>
+      </article>
+
+      <!-- Samoota (past) -->
+      <article class="card event-card past">
+        <div class="thumb-wrap">
+          <img class="thumb" src="data/images/samoota-poster.jpg"
+               alt="Samoota — In the Shadow of Three Suns"
+               onerror="this.style.display='none'">
+          <span class="date-badge">15 Feb 2025</span>
+        </div>
+        <div class="card-body">
+          <h4 class="card-title">Samoota — In the Shadow of Three Suns</h4>
+          <p class="card-desc">
+            Audiovisual exhibition by Petter Schiölander at Indra Gallery with
+            afterparty DJ sets by in-soo, Sweeep &amp; Thirty3.
+          </p>
+          <p class="card-meta">Indra Gallery — London, UK</p>
+          <a class="btn btn--ghost" target="_blank" rel="noopener"
+             href="https://www.trip.com/events/samoota-in-the-shadow-of-three-suns--art-gallery--exhibition-20250120/">
+            View details
+          </a>
+        </div>
+      </article>
+    </div>
   </section>
 
   <section class="wk-grid" id="wkGrid" aria-live="polite"></section>


### PR DESCRIPTION
## Summary
- replace the Events markup with a grid of cards that shares the work card structure and spacing
- restyle event cards to reuse the work card look with subtle typography, placeholders, and a smaller date badge

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e1506a8760832fbe45387850b2ffcc