### PR TITLE
Add events shortcut link to Work hero

### DIFF
--- a/style.css
+++ b/style.css
@@ -164,6 +164,49 @@ body.home{
   gap:18px;
 }
 
+/* Work header wrapper so the link can sit on the right */
+.work-intro {
+  position: relative;
+  padding-right: 140px;
+}
+
+/* Events → pill link */
+.event-link {
+  display: inline-block;
+  border: 1px solid #444;
+  border-radius: 9999px;
+  padding: 6px 16px;
+  color: #a6fff6;
+  text-decoration: none;
+  font-size: 0.9rem;
+  line-height: 1;
+  position: absolute;
+  right: 4%;
+  top: 2px;
+  transition: all 0.25s ease;
+}
+.event-link:hover {
+  background-color: #a6fff6;
+  color: #000;
+  border-color: #a6fff6;
+}
+
+/* Mobile: place under title/filters, no overlap */
+@media (max-width: 640px) {
+  .work-intro {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+    padding-right: 0;
+  }
+  .event-link {
+    position: static;
+    margin-left: auto;
+    order: 3;
+  }
+}
+
 /* Chip med pil */
 .chip.chip--ghost {
   background: transparent;

--- a/work-test.html
+++ b/work-test.html
@@ -396,8 +396,12 @@
 
   <section class="wk-hero">
     <p class="wk-eyebrow">SELECTED</p>
-    <h1 class="wk-title">Work</h1>
-    <p class="wk-sub">Solo pieces, collaborations and live/visual projects.</p>
+    <div class="work-intro">
+      <h1 class="wk-title">Work</h1>
+      <p class="wk-sub">Solo pieces, collaborations and live/visual projects.</p>
+
+      <a class="event-link" href="#events" aria-label="Jump to events">Events →</a>
+    </div>
 
     <div class="filter-row">
       <div class="wk-tabs" role="tablist" aria-label="Work categories">
@@ -410,7 +414,7 @@
       <button id="eventsToggle"
               class="chip chip--ghost"
               aria-expanded="false"
-              aria-controls="eventsPanel">
+              aria-controls="events">
         Events
         <span class="chev" aria-hidden="true"></span>
       </button>
@@ -418,7 +422,7 @@
   </section>
 
   <!-- Collapsible Events panel (start collapsed) -->
-  <section id="eventsPanel" class="events-panel" hidden>
+  <section id="events" class="events-panel" hidden>
     <div class="events-panel__inner">
       <div class="work-grid events-grid">
         <!-- KTH -->
@@ -1387,7 +1391,8 @@ async function loadMemoriesAlbum(){
   <script>
 (function () {
   const btn = document.getElementById('eventsToggle');
-  const panel = document.getElementById('eventsPanel');
+  const panel = document.getElementById('events');
+  const eventLink = document.querySelector('.event-link');
 
   if (!btn || !panel) return;
 
@@ -1412,6 +1417,25 @@ async function loadMemoriesAlbum(){
     const expanded = btn.getAttribute('aria-expanded') === 'true';
     expanded ? close() : open();
   });
+
+  if (eventLink) {
+    eventLink.addEventListener('click', (event) => {
+      event.preventDefault();
+      if (btn.getAttribute('aria-expanded') !== 'true') {
+        open();
+      }
+      requestAnimationFrame(() => {
+        panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      });
+    });
+  }
+
+  if (window.location.hash === '#events') {
+    open();
+    requestAnimationFrame(() => {
+      panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  }
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add a dedicated Events → link inside the Work hero intro and ensure it opens the events panel when used
- style the link to float on the right for desktop while stacking neatly on mobile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e16c7b8d60832f8e98d304e49b30d1