### PR TITLE
Add Luxor NITEFISH collaboration to work grid

### DIFF
--- a/work.html
+++ b/work.html
@@ -698,6 +698,16 @@ let PROJECTS = [
     ]
   },
   {
+    title: "LUXOR – NITEFISH ft. Thirty3 & Beauty96",
+    kind: "collab",
+    thumb: "auto",
+    media: { type: "embed", src: "https://www.youtube.com/embed/g4xM4fT87IE" },
+    desc: "Music video by NITEFISH featuring Thirty3 & Beauty96.",
+    links: [
+      { label: "Watch (YouTube)", href: "https://www.youtube.com/watch?v=g4xM4fT87IE" }
+    ]
+  },
+  {
     title: "Spacey Shit – NITEFISH (prod. Thirty3)",
     kind: "collab",
     thumb: "sauna_radio_spacey.jpg",


### PR DESCRIPTION
## Summary
- add the Luxor NITEFISH collaboration card to the projects list with YouTube embed and description
- ensure it appears under collabs/all with existing filtering and modal behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69440cf2cad4832f80e93ee331824feb)